### PR TITLE
Fix error

### DIFF
--- a/custom_components/u_tec/api.py
+++ b/custom_components/u_tec/api.py
@@ -7,6 +7,7 @@ from aiohttp import ClientSession, web
 from homeassistant.components import webhook
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow, network
+from homeassistant.helpers.network import NoURLAvailableError
 from utec_py.api import AbstractAuth, UHomeApi
 from utec_py.exceptions import ApiError, UHomeError, ValidationError
 
@@ -49,7 +50,14 @@ class AsyncPushUpdateHandler:
         """Register webhook with Home Assistant and the Uhome API."""
 
         # Get the external URL
-        external_url = network.get_url(self.hass, allow_internal=False)
+        try:
+            external_url = network.get_url(self.hass, allow_internal=False)
+        except NoURLAvailableError:
+            _LOGGER.error(
+                "External URL not configured, push notifications will not work"
+            )
+            return False
+
         if not external_url:
             _LOGGER.error(
                 "External URL not configured, push notifications will not work"


### PR DESCRIPTION
Fixed by adding error handling.


Error Log:
```
Error setting up entry U-tech for u_tec
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 761, in __async_setup_with_context
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/u_tec/__init__.py", line 61, in async_setup_entry
    await webhook_handler.async_register_webhook(auth_data)
  File "/config/custom_components/u_tec/api.py", line 52, in async_register_webhook
    external_url = network.get_url(self.hass, allow_internal=False)
  File "/usr/src/homeassistant/homeassistant/helpers/network.py", line 211, in get_url
    raise NoURLAvailableError
homeassistant.helpers.network.NoURLAvailableError
```