### PR TITLE
ci: add GitHub Actions workflow to run tests on push and PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: pip install -r requirements-test.txt
+      - run: pytest --cov --cov-report=term-missing

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,10 @@
+pytest>=8.0
+pytest-asyncio>=0.24
+pytest-cov>=5.0
+coverage[toml]>=7.4
+aioresponses>=0.7.6
+pytest-homeassistant-custom-component>=0.13.200
+
+# Integration runtime dep — must match manifest.json so the test suite
+# exercises the same utec_py source as the integration.
+utec_py_LF2b2w @ git+https://github.com/geofffranks/utec-py.git@main


### PR DESCRIPTION
Mirrors utec-py's test.yml — single Python 3.12 job that installs requirements-test.txt and runs pytest with coverage. The coverage gate (fail_under=85 in pyproject.toml) is enforced automatically.

Pins the integration runtime dep (utec_py_LF2b2w) into requirements-test.txt so CI installs the same source the manifest pulls from at runtime.