### PR TITLE
fix(lock): stop optimistic state from reporting a lock incorrectly (unbounded optimism, Passage mode)

### DIFF
--- a/custom_components/u_tec/const.py
+++ b/custom_components/u_tec/const.py
@@ -1,5 +1,7 @@
 """Constants for the Uhome integration."""
 
+from datetime import timedelta
+
 from .optimistic import (
     CONF_OPTIMISTIC_LIGHTS,
     CONF_OPTIMISTIC_SWITCHES,
@@ -9,6 +11,15 @@ from .optimistic import (
 )
 
 DOMAIN = "u_tec"
+
+# Bound how long an unconfirmed optimistic state may override the device's
+# reported state, shared by lock/light/switch. Without it, a command the
+# device never fulfils (a lock auto-locking after an unlock, a switch command
+# that silently fails) pins the entity permanently. ~3 polls at the default
+# 10s scan interval preserves the grace period while the device physically
+# settles, then defers to the device.
+# https://github.com/LF2b2w/Uhome-HA/issues/58
+OPTIMISTIC_TIMEOUT = timedelta(seconds=30)
 
 CONF_SCAN_INTERVAL = "scan_interval"
 CONF_DISCOVERY_INTERVAL = "discovery_interval"

--- a/custom_components/u_tec/const.py
+++ b/custom_components/u_tec/const.py
@@ -8,6 +8,7 @@ from .optimistic import (
     CONF_OPTIMISTIC_LOCKS,
     DEFAULT_OPTIMISTIC,
     is_optimistic_enabled,
+    push_asserts_state,
 )
 
 DOMAIN = "u_tec"

--- a/custom_components/u_tec/light.py
+++ b/custom_components/u_tec/light.py
@@ -1,6 +1,7 @@
 """Support for Uhome lights."""
 
 import logging
+from datetime import datetime
 from typing import Any, cast
 
 from homeassistant.components.light import (
@@ -17,6 +18,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 from homeassistant.util.color import value_to_brightness
 from utec_py.devices.light import Light as UhomeLight
 from utec_py.exceptions import DeviceError
@@ -24,6 +26,7 @@ from utec_py.exceptions import DeviceError
 from .const import (
     CONF_OPTIMISTIC_LIGHTS,
     DOMAIN,
+    OPTIMISTIC_TIMEOUT,
     SIGNAL_DEVICE_UPDATE,
     is_optimistic_enabled,
 )
@@ -31,6 +34,12 @@ from .coordinator import UhomeDataUpdateCoordinator
 
 # use module-level logger
 _LOGGER = logging.getLogger(__name__)
+
+# The optimistic timeout and on/off push-clear handling below mirrors lock.py,
+# which was verified on real hardware. The light path uses the same logic but
+# is unverified on a live U-Tec light. Brightness is intentionally left to the
+# confirm/timeout path (see _handle_push_update).
+# https://github.com/LF2b2w/Uhome-HA/issues/58
 
 # U-Tec reports brightness as 1-100, not 0-100. 
 BRIGHTNESS_SCALE = (1, 100)
@@ -61,6 +70,7 @@ class UhomeLightEntity(CoordinatorEntity, LightEntity):
     _optimistic_is_on: bool | None = None
     _optimistic_brightness: int | None = None
     _pending_brightness_utec: int | None = None
+    _optimistic_set_at: datetime | None = None
 
     def __init__(self, coordinator: UhomeDataUpdateCoordinator, device_id: str) -> None:
         """Initialize the light."""
@@ -81,6 +91,7 @@ class UhomeLightEntity(CoordinatorEntity, LightEntity):
         # The U-Tec brightness value (1-100) we last sent, used to detect
         # when the device has confirmed the change so we can clear optimistic state.
         self._pending_brightness_utec: int | None = None
+        self._optimistic_set_at: datetime | None = None
 
         # Set supported color modes based on device capabilities
         self._attr_supported_color_modes = set()
@@ -158,12 +169,21 @@ class UhomeLightEntity(CoordinatorEntity, LightEntity):
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from coordinator.
 
-        For both on/off and brightness, only clear optimistic state once the
-        device confirms the new value — the first poll after a command often
-        still returns the old value.
+        For both on/off and brightness, we do not clear optimistic state on the
+        first poll (which often still returns the old value), but we also do not
+        wait forever: optimism is held for at most OPTIMISTIC_TIMEOUT, then
+        released so a command the device never fulfils cannot pin the entity.
+        A single shared clock covers both tracks of a turn_on call.
         """
+        timed_out = (
+            self._optimistic_set_at is not None
+            and dt_util.utcnow() - self._optimistic_set_at > OPTIMISTIC_TIMEOUT
+        )
+
         if self._optimistic_is_on is not None:
             if self._optimistic_is_on == self._device.is_on:
+                self._optimistic_is_on = None
+            elif timed_out:
                 self._optimistic_is_on = None
             # else: keep optimistic state until device catches up
 
@@ -173,9 +193,20 @@ class UhomeLightEntity(CoordinatorEntity, LightEntity):
             if actual is not None and actual == pending:
                 self._optimistic_brightness = None
                 self._pending_brightness_utec = None
+            elif timed_out:
+                self._optimistic_brightness = None
+                self._pending_brightness_utec = None
             # else: keep optimistic brightness until device catches up
         else:
             self._optimistic_brightness = None
+
+        # Shared clock: clear it once nothing optimistic remains; start it if
+        # optimism is outstanding but was set without a timestamp (e.g. cache
+        # restore), so the timeout above can bound it on a later pass.
+        if self._optimistic_is_on is None and self._pending_brightness_utec is None:
+            self._optimistic_set_at = None
+        elif self._optimistic_set_at is None:
+            self._optimistic_set_at = dt_util.utcnow()
 
         super()._handle_coordinator_update()
 
@@ -215,6 +246,7 @@ class UhomeLightEntity(CoordinatorEntity, LightEntity):
                 if "brightness" in turn_on_args:
                     self._optimistic_brightness = kwargs[ATTR_BRIGHTNESS]
                     self._pending_brightness_utec = turn_on_args["brightness"]
+                self._optimistic_set_at = dt_util.utcnow()
                 self.async_write_ha_state()
 
         except DeviceError as err:
@@ -228,6 +260,7 @@ class UhomeLightEntity(CoordinatorEntity, LightEntity):
             await self._device.turn_off()
             if self._is_optimistic():
                 self._optimistic_is_on = False
+                self._optimistic_set_at = dt_util.utcnow()
                 self.async_write_ha_state()
         except DeviceError as err:
             _LOGGER.error(
@@ -249,5 +282,24 @@ class UhomeLightEntity(CoordinatorEntity, LightEntity):
 
     @callback
     def _handle_push_update(self, push_data) -> None:
-        """Update device from push data."""
+        """Update device from push data, clearing on/off optimism on disagreement.
+
+        The coordinator applies the push before dispatching, so
+        self._device.is_on reflects the pushed state. A push contradicting an
+        outstanding on/off optimistic value is authoritative, so drop it now
+        instead of waiting out OPTIMISTIC_TIMEOUT.
+
+        Brightness is intentionally NOT cleared here: a push during a dimming
+        ramp can carry an intermediate value, so a brightness mismatch is not
+        reliably authoritative. It stays on the confirm/timeout path.
+        """
+        if (
+            self._optimistic_is_on is not None
+            and self._optimistic_is_on != self._device.is_on
+        ):
+            self._optimistic_is_on = None
+
+        if self._optimistic_is_on is None and self._pending_brightness_utec is None:
+            self._optimistic_set_at = None
+
         self.async_write_ha_state()

--- a/custom_components/u_tec/light.py
+++ b/custom_components/u_tec/light.py
@@ -29,6 +29,7 @@ from .const import (
     OPTIMISTIC_TIMEOUT,
     SIGNAL_DEVICE_UPDATE,
     is_optimistic_enabled,
+    push_asserts_state,
 )
 from .coordinator import UhomeDataUpdateCoordinator
 
@@ -180,6 +181,16 @@ class UhomeLightEntity(CoordinatorEntity, LightEntity):
             and dt_util.utcnow() - self._optimistic_set_at > OPTIMISTIC_TIMEOUT
         )
 
+        if timed_out and (
+            self._optimistic_is_on is not None
+            or self._pending_brightness_utec is not None
+        ):
+            _LOGGER.debug(
+                "Optimistic state for %s unconfirmed after %s; trusting device",
+                self._device.device_id,
+                OPTIMISTIC_TIMEOUT,
+            )
+
         if self._optimistic_is_on is not None:
             if self._optimistic_is_on == self._device.is_on:
                 self._optimistic_is_on = None
@@ -285,9 +296,11 @@ class UhomeLightEntity(CoordinatorEntity, LightEntity):
         """Update device from push data, clearing on/off optimism on disagreement.
 
         The coordinator applies the push before dispatching, so
-        self._device.is_on reflects the pushed state. A push contradicting an
-        outstanding on/off optimistic value is authoritative, so drop it now
-        instead of waiting out OPTIMISTIC_TIMEOUT.
+        self._device.is_on reflects the pushed state. We only act when the push
+        actually carried switch state (pushes are full-state replaces and
+        Light.is_on falls back to False when the switch capability is absent, so
+        a partial push must not read as a spurious "off"). A contradicting push
+        then drops on/off optimism now instead of waiting out OPTIMISTIC_TIMEOUT.
 
         Brightness is intentionally NOT cleared here: a push during a dimming
         ramp can carry an intermediate value, so a brightness mismatch is not
@@ -295,6 +308,7 @@ class UhomeLightEntity(CoordinatorEntity, LightEntity):
         """
         if (
             self._optimistic_is_on is not None
+            and push_asserts_state(push_data, "st.switch", "switch")
             and self._optimistic_is_on != self._device.is_on
         ):
             self._optimistic_is_on = None

--- a/custom_components/u_tec/lock.py
+++ b/custom_components/u_tec/lock.py
@@ -1,7 +1,7 @@
 """Support for Uhome locks."""
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any, cast
 
 from homeassistant.components.lock import LockEntity
@@ -19,6 +19,7 @@ from utec_py.exceptions import DeviceError
 from .const import (
     CONF_OPTIMISTIC_LOCKS,
     DOMAIN,
+    OPTIMISTIC_TIMEOUT,
     SIGNAL_DEVICE_UPDATE,
     is_optimistic_enabled,
 )
@@ -26,18 +27,11 @@ from .coordinator import UhomeDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-# Bound how long an unconfirmed optimistic state may override the device's
-# reported state. Without this, a command the device never fulfils (for
-# example the lock auto-locking straight after an unlock) pins the entity
-# permanently. https://github.com/LF2b2w/Uhome-HA/issues/58
-#
-# NOTE: light.py and switch.py clear optimistic state on confirmation only,
-# exactly as this module used to, and so share the same unbounded behaviour.
-# They are deliberately left alone here: this fix is scoped to the platform
-# whose failure was reproduced on hardware, and the equivalent change to
-# lights and switches should be made by someone who can verify it against a
-# real device rather than by extrapolation.
-OPTIMISTIC_TIMEOUT = timedelta(seconds=30)
+# OPTIMISTIC_TIMEOUT lives in const.py because light.py and switch.py share
+# the same bounding. Only the lock path was reproduced on real hardware (an
+# ULTRALOQ Latch-5-F, whose non-disableable auto-lock guarantees the pin);
+# the light/switch fixes mirror this logic but are unverified on live
+# hardware. https://github.com/LF2b2w/Uhome-HA/issues/58
 
 # utec_py maps LockMode.PASSAGE -> "Passage" (devices/lock.py::lock_mode).
 # In this mode the device ignores lock/unlock commands outright.
@@ -107,6 +101,15 @@ class UhomeLockEntity(CoordinatorEntity, LockEntity):
         state event, so its tile sticks on "Locking..." indefinitely.
         Re-asserting the true state gives them an event to act on without
         publishing anything false.
+
+        This relies on Entity._async_write_ha_state reading force_update
+        synchronously during the write (it passes the value straight into the
+        state machine, which suppresses the state-changed event for an
+        identical state unless force_update is set). That is verified against
+        current HA internals, not a contractual API: if a future HA version
+        caches force_update at registration or defers the write, this toggle
+        would silently stop emitting the event. The finally-reset and
+        test_force_update_reset_even_if_write_raises guard the toggle itself.
         """
         self._force_next_write = True
         try:
@@ -258,5 +261,25 @@ class UhomeLockEntity(CoordinatorEntity, LockEntity):
 
     @callback
     def _handle_push_update(self, push_data):
-        """Update device from push data."""
+        """Update device from push data, clearing optimistic state on disagreement.
+
+        By the time this fires, the coordinator has already applied the push to
+        the device (coordinator.update_push_data calls device.update_state_data
+        before dispatching), so self._device.is_locked reflects the pushed
+        state. A push is the most authoritative signal available -- the device
+        is proactively announcing a settled state -- so if it contradicts an
+        outstanding optimistic value we drop the optimism immediately rather
+        than waiting out OPTIMISTIC_TIMEOUT. This corrects the #58 auto-lock
+        case (device re-locks itself after an unlock) within seconds.
+
+        A push that agrees, or that does not change the lock state, leaves the
+        optimistic flag for the existing confirm/timeout path in
+        _handle_coordinator_update.
+        """
+        if (
+            self._optimistic_is_locked is not None
+            and self._optimistic_is_locked != self._device.is_locked
+        ):
+            self._optimistic_is_locked = None
+            self._optimistic_set_at = None
         self.async_write_ha_state()

--- a/custom_components/u_tec/lock.py
+++ b/custom_components/u_tec/lock.py
@@ -1,6 +1,7 @@
 """Support for Uhome locks."""
 
 import logging
+from datetime import datetime, timedelta
 from typing import Any, cast
 
 from homeassistant.components.lock import LockEntity
@@ -11,6 +12,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 from utec_py.devices.lock import Lock as UhomeLock
 from utec_py.exceptions import DeviceError
 
@@ -23,6 +25,23 @@ from .const import (
 from .coordinator import UhomeDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+# Bound how long an unconfirmed optimistic state may override the device's
+# reported state. Without this, a command the device never fulfils (for
+# example the lock auto-locking straight after an unlock) pins the entity
+# permanently. https://github.com/LF2b2w/Uhome-HA/issues/58
+#
+# NOTE: light.py and switch.py clear optimistic state on confirmation only,
+# exactly as this module used to, and so share the same unbounded behaviour.
+# They are deliberately left alone here: this fix is scoped to the platform
+# whose failure was reproduced on hardware, and the equivalent change to
+# lights and switches should be made by someone who can verify it against a
+# real device rather than by extrapolation.
+OPTIMISTIC_TIMEOUT = timedelta(seconds=30)
+
+# utec_py maps LockMode.PASSAGE -> "Passage" (devices/lock.py::lock_mode).
+# In this mode the device ignores lock/unlock commands outright.
+PASSAGE_MODE = "Passage"
 
 
 async def async_setup_entry(
@@ -46,6 +65,8 @@ class UhomeLockEntity(CoordinatorEntity, LockEntity):
     """Representation of a Uhome lock."""
 
     _optimistic_is_locked: bool | None = None
+    _optimistic_set_at: datetime | None = None
+    _force_next_write: bool = False
 
     def __init__(self, coordinator: UhomeDataUpdateCoordinator, device_id: str) -> None:
         """Initialize the lock."""
@@ -62,9 +83,48 @@ class UhomeLockEntity(CoordinatorEntity, LockEntity):
         )
         self._attr_has_entity_name = True
         self._optimistic_is_locked: bool | None = None
+        self._optimistic_set_at: datetime | None = None
+        self._force_next_write = False
+
+    @property
+    def force_update(self) -> bool:
+        """Return True to write state even when it has not changed.
+
+        Entity._async_write_ha_state passes this to the state machine, which
+        skips the state-changed event when the new state is identical unless
+        force_update is set. Toggling it around a single write therefore emits
+        a real event for an otherwise-identical state. See _resync_listeners.
+        """
+        return self._force_next_write
+
+    def _resync_listeners(self) -> None:
+        """Re-emit the current (unchanged) state as a real state event.
+
+        In Passage mode a lock command changes nothing, so no state event would
+        fire. Consumers that only recompute on a state change never learn the
+        command was a no-op -- HA's HomeKit bridge, for one, recomputes its
+        lock target characteristic in async_update_state, which runs only on a
+        state event, so its tile sticks on "Locking..." indefinitely.
+        Re-asserting the true state gives them an event to act on without
+        publishing anything false.
+        """
+        self._force_next_write = True
+        try:
+            self.async_write_ha_state()
+        finally:
+            self._force_next_write = False
 
     def _is_optimistic(self) -> bool:
-        """Return True if optimistic updates apply to this device."""
+        """Return True if optimistic updates apply to this device.
+
+        Passage mode ignores lock/unlock commands, so a new optimistic state
+        would always be wrong there; report the polled truth instead.
+        Optimism outstanding from before the mode changed is dropped in
+        _handle_coordinator_update rather than here, so that is_locked and
+        assumed_state cannot disagree.
+        """
+        if self._device.lock_mode == PASSAGE_MODE:
+            return False
         return is_optimistic_enabled(
             self.coordinator.config_entry.options,
             CONF_OPTIMISTIC_LOCKS,
@@ -96,18 +156,36 @@ class UhomeLockEntity(CoordinatorEntity, LockEntity):
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from coordinator, clearing optimistic state.
 
-        Lock/unlock commands are slow (physical deadbolt movement) so we only
-        clear the optimistic state once the device confirms the new lockState,
-        rather than on the first poll which may still return the old value.
+        Lock/unlock commands are slow (physical deadbolt movement) so we do not
+        clear the optimistic state on the first poll, which may still return the
+        old value. But we cannot wait forever either: if the device never
+        reaches the commanded state the entity would stay wrong indefinitely.
+        So optimism is held for OPTIMISTIC_TIMEOUT and then released.
         """
         if self._optimistic_is_locked is not None:
-            confirmed = (
-                self._optimistic_is_locked and self._device.is_locked
-                or not self._optimistic_is_locked and not self._device.is_locked
-            )
-            if confirmed:
+            if self._device.lock_mode == PASSAGE_MODE:
+                # The lock entered Passage mode while optimism was outstanding.
+                # It will never confirm, and _is_optimistic() now reports False,
+                # so holding on would make is_locked return an assumed value
+                # while assumed_state claims it is confirmed. Drop it now.
                 self._optimistic_is_locked = None
-            # else: keep optimistic state until device catches up
+                self._optimistic_set_at = None
+            elif self._optimistic_is_locked == self._device.is_locked:
+                self._optimistic_is_locked = None
+                self._optimistic_set_at = None
+            elif self._optimistic_set_at is None:
+                # Optimistic value with no timestamp: start the clock now
+                # rather than clearing, so the grace period is preserved.
+                self._optimistic_set_at = dt_util.utcnow()
+            elif dt_util.utcnow() - self._optimistic_set_at > OPTIMISTIC_TIMEOUT:
+                _LOGGER.debug(
+                    "Optimistic state for %s unconfirmed after %s; trusting device",
+                    self._device.device_id,
+                    OPTIMISTIC_TIMEOUT,
+                )
+                self._optimistic_is_locked = None
+                self._optimistic_set_at = None
+            # else: still within the grace period while the bolt moves
         super()._handle_coordinator_update()
 
     @property
@@ -131,18 +209,36 @@ class UhomeLockEntity(CoordinatorEntity, LockEntity):
             await self._device.lock()
             if self._is_optimistic():
                 self._optimistic_is_locked = True
+                self._optimistic_set_at = dt_util.utcnow()
                 self.async_write_ha_state()
+            elif self._device.lock_mode == PASSAGE_MODE:
+                # Passage mode ignores the command, so no state change will
+                # follow and HomeKit would hang on "Locking...". Re-assert the
+                # true state so the bridge resets its target characteristic.
+                _LOGGER.debug(
+                    "%s is in Passage mode; lock command ignored, resyncing"
+                    " listeners with the unchanged state",
+                    self._device.device_id,
+                )
+                self._resync_listeners()
         except DeviceError as err:
             _LOGGER.error("Failed to lock device %s: %s", self._device.device_id, err)
             raise HomeAssistantError(f"Failed to lock: {err}") from err
 
     async def async_unlock(self, **kwargs: Any) -> None:
-        """Unlock the device."""
+        """Unlock the device.
+
+        Deliberately has no Passage-mode resync counterpart to async_lock: a
+        lock in Passage mode already reports itself unlocked, so an unlock
+        command leaves consumers' target and current states in agreement and
+        nothing can hang. Only the lock direction can diverge.
+        """
         _LOGGER.debug("Unlocking device %s", self._device.device_id)
         try:
             await self._device.unlock()
             if self._is_optimistic():
                 self._optimistic_is_locked = False
+                self._optimistic_set_at = dt_util.utcnow()
                 self.async_write_ha_state()
         except DeviceError as err:
             _LOGGER.error("Failed to unlock device %s: %s", self._device.device_id, err)

--- a/custom_components/u_tec/lock.py
+++ b/custom_components/u_tec/lock.py
@@ -22,6 +22,7 @@ from .const import (
     OPTIMISTIC_TIMEOUT,
     SIGNAL_DEVICE_UPDATE,
     is_optimistic_enabled,
+    push_asserts_state,
 )
 from .coordinator import UhomeDataUpdateCoordinator
 
@@ -266,18 +267,21 @@ class UhomeLockEntity(CoordinatorEntity, LockEntity):
         By the time this fires, the coordinator has already applied the push to
         the device (coordinator.update_push_data calls device.update_state_data
         before dispatching), so self._device.is_locked reflects the pushed
-        state. A push is the most authoritative signal available -- the device
-        is proactively announcing a settled state -- so if it contradicts an
-        outstanding optimistic value we drop the optimism immediately rather
-        than waiting out OPTIMISTIC_TIMEOUT. This corrects the #58 auto-lock
-        case (device re-locks itself after an unlock) within seconds.
+        state. A push that authoritatively contradicts an outstanding optimistic
+        value drops the optimism immediately rather than waiting out
+        OPTIMISTIC_TIMEOUT -- this corrects the #58 auto-lock case (device
+        re-locks itself after an unlock) within seconds.
 
-        A push that agrees, or that does not change the lock state, leaves the
-        optimistic flag for the existing confirm/timeout path in
-        _handle_coordinator_update.
+        We only act when the push actually carried lock state: pushes are
+        full-state replaces, and Lock.is_locked falls back to False when the
+        lock capability is absent, so a partial push (e.g. a door-sensor event)
+        would otherwise read as a spurious "unlocked" and clear optimism
+        mid-command. A push that agrees, omits lock state, or leaves it
+        unchanged stays on the confirm/timeout path.
         """
         if (
             self._optimistic_is_locked is not None
+            and push_asserts_state(push_data, "st.lock", "lockState")
             and self._optimistic_is_locked != self._device.is_locked
         ):
             self._optimistic_is_locked = None

--- a/custom_components/u_tec/optimistic.py
+++ b/custom_components/u_tec/optimistic.py
@@ -31,3 +31,24 @@ def is_optimistic_enabled(
     if isinstance(value, bool):
         return value
     return device_id in value
+
+
+def push_asserts_state(push_data: Any, capability: str, attribute: str) -> bool:
+    """Return True if a push payload actually carries the given capability state.
+
+    U-Tec pushes are full-state replaces (utec_py update_state_data assigns the
+    payload wholesale), and the device accessors fall back to a default when a
+    capability is absent -- e.g. Lock.is_locked and Switch.is_on both return
+    False when their capability is missing, which is indistinguishable from a
+    real "unlocked"/"off". A partial push (a door-sensor or battery event that
+    omits the lock/switch state) would therefore read as an authoritative
+    "off"/"unlocked" and wrongly clear optimistic state mid-command.
+
+    push_data is the {capability: {attribute: value}} dict produced by
+    device.get_state_data(); only treat a push as asserting the state when the
+    relevant capability/attribute is actually present in it.
+    """
+    if not isinstance(push_data, dict):
+        return False
+    cap = push_data.get(capability)
+    return isinstance(cap, dict) and attribute in cap

--- a/custom_components/u_tec/switch.py
+++ b/custom_components/u_tec/switch.py
@@ -1,5 +1,6 @@
 """Support for Uhome switches."""
 
+from datetime import datetime
 from typing import Any, cast
 import logging
 
@@ -11,12 +12,14 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 from utec_py.devices.switch import Switch as UhomeSwitch
 from utec_py.exceptions import DeviceError
 
 from .const import (
     CONF_OPTIMISTIC_SWITCHES,
     DOMAIN,
+    OPTIMISTIC_TIMEOUT,
     SIGNAL_DEVICE_UPDATE,
     is_optimistic_enabled,
 )
@@ -24,6 +27,10 @@ from .coordinator import UhomeDataUpdateCoordinator
 
 # define our own logger so we don't import the private internal logger, and instead use a module logger
 _LOGGER = logging.getLogger(__name__)
+
+# The optimistic timeout and push-clear handling below mirrors lock.py, which
+# was verified on real hardware. The switch path uses the same logic but is
+# unverified on a live U-Tec switch. https://github.com/LF2b2w/Uhome-HA/issues/58
 
 
 async def async_setup_entry(
@@ -47,6 +54,7 @@ class UhomeSwitchEntity(CoordinatorEntity, SwitchEntity):
     """Representation of a Uhome switch."""
 
     _optimistic_is_on: bool | None = None
+    _optimistic_set_at: datetime | None = None
 
     def __init__(self, coordinator: UhomeDataUpdateCoordinator, device_id: str) -> None:
         """Initialize the switch."""
@@ -63,6 +71,7 @@ class UhomeSwitchEntity(CoordinatorEntity, SwitchEntity):
         )
         self._attr_has_entity_name = True
         self._optimistic_is_on: bool | None = None
+        self._optimistic_set_at: datetime | None = None
 
     def _is_optimistic(self) -> bool:
         """Return True if optimistic updates apply to this device."""
@@ -90,11 +99,29 @@ class UhomeSwitchEntity(CoordinatorEntity, SwitchEntity):
         return self._is_optimistic() and self._optimistic_is_on is not None
 
     def _handle_coordinator_update(self) -> None:
-        """Handle updated data from coordinator, clearing optimistic state."""
+        """Handle updated data from coordinator, clearing optimistic state.
+
+        Optimism is held while the device catches up, but only for
+        OPTIMISTIC_TIMEOUT -- otherwise a command the device never fulfils
+        would pin the entity indefinitely. See lock.py for the reproduced case.
+        """
         if self._optimistic_is_on is not None:
             if self._optimistic_is_on == self._device.is_on:
                 self._optimistic_is_on = None
-            # else: keep optimistic state until device catches up
+                self._optimistic_set_at = None
+            elif self._optimistic_set_at is None:
+                # Optimistic value with no timestamp: start the clock rather
+                # than clearing, so the grace period is preserved.
+                self._optimistic_set_at = dt_util.utcnow()
+            elif dt_util.utcnow() - self._optimistic_set_at > OPTIMISTIC_TIMEOUT:
+                _LOGGER.debug(
+                    "Optimistic state for %s unconfirmed after %s; trusting device",
+                    self._device.device_id,
+                    OPTIMISTIC_TIMEOUT,
+                )
+                self._optimistic_is_on = None
+                self._optimistic_set_at = None
+            # else: still within the grace period
         super()._handle_coordinator_update()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -104,6 +131,7 @@ class UhomeSwitchEntity(CoordinatorEntity, SwitchEntity):
             await self._device.turn_on()
             if self._is_optimistic():
                 self._optimistic_is_on = True
+                self._optimistic_set_at = dt_util.utcnow()
                 self.async_write_ha_state()
         except DeviceError as err:
             _LOGGER.error(
@@ -118,6 +146,7 @@ class UhomeSwitchEntity(CoordinatorEntity, SwitchEntity):
             await self._device.turn_off()
             if self._is_optimistic():
                 self._optimistic_is_on = False
+                self._optimistic_set_at = dt_util.utcnow()
                 self.async_write_ha_state()
         except DeviceError as err:
             _LOGGER.error(
@@ -139,5 +168,17 @@ class UhomeSwitchEntity(CoordinatorEntity, SwitchEntity):
 
     @callback
     def _handle_push_update(self, push_data):
-        """Update device from push data."""
+        """Update device from push data, clearing optimistic state on disagreement.
+
+        The coordinator applies the push to the device before dispatching, so
+        self._device.is_on reflects the pushed state. A push that contradicts
+        an outstanding optimistic value is authoritative, so drop the optimism
+        at once rather than waiting out OPTIMISTIC_TIMEOUT.
+        """
+        if (
+            self._optimistic_is_on is not None
+            and self._optimistic_is_on != self._device.is_on
+        ):
+            self._optimistic_is_on = None
+            self._optimistic_set_at = None
         self.async_write_ha_state()

--- a/custom_components/u_tec/switch.py
+++ b/custom_components/u_tec/switch.py
@@ -22,6 +22,7 @@ from .const import (
     OPTIMISTIC_TIMEOUT,
     SIGNAL_DEVICE_UPDATE,
     is_optimistic_enabled,
+    push_asserts_state,
 )
 from .coordinator import UhomeDataUpdateCoordinator
 
@@ -171,12 +172,16 @@ class UhomeSwitchEntity(CoordinatorEntity, SwitchEntity):
         """Update device from push data, clearing optimistic state on disagreement.
 
         The coordinator applies the push to the device before dispatching, so
-        self._device.is_on reflects the pushed state. A push that contradicts
-        an outstanding optimistic value is authoritative, so drop the optimism
-        at once rather than waiting out OPTIMISTIC_TIMEOUT.
+        self._device.is_on reflects the pushed state. We only act when the push
+        actually carried switch state: pushes are full-state replaces and
+        Switch.is_on falls back to False when the switch capability is absent,
+        so a partial push must not be read as a spurious "off". A contradicting
+        push then drops the optimism at once rather than waiting out
+        OPTIMISTIC_TIMEOUT.
         """
         if (
             self._optimistic_is_on is not None
+            and push_asserts_state(push_data, "st.switch", "switch")
             and self._optimistic_is_on != self._device.is_on
         ):
             self._optimistic_is_on = None

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -497,21 +497,71 @@ def test_handle_push_update_calls_write_ha_state(coord_with_light):
 # hardware). https://github.com/LF2b2w/Uhome-HA/issues/58
 # ---------------------------------------------------------------------------
 
+# Push payloads with and without the switch capability (light on/off lives
+# under st.switch, same as switch.py).
+_PUSH_WITH_SWITCH = {"st.switch": {"switch": "on"}}
+_PUSH_NO_SWITCH = {"st.batteryLevel": {"level": 3}}
+
+
+def test_light_onoff_held_during_grace_with_fresh_stamp(coord_with_light):
+    """With a fresh stamp and the device disagreeing, optimism is HELD, not
+    cleared -- the grace period that lets the light physically settle."""
+    coord, light = coord_with_light
+    ent = UhomeLightEntity(coord, "light-1")
+    ent.hass = MagicMock()
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_on = True
+    ent._optimistic_set_at = dt_util.utcnow()  # just commanded
+    light.is_on = False  # device hasn't caught up
+
+    ent._handle_coordinator_update()
+    assert ent._optimistic_is_on is True  # held within grace
+
+
+def test_light_onoff_missing_stamp_starts_clock(coord_with_light):
+    """Optimism set without a stamp starts the clock rather than clearing."""
+    coord, light = coord_with_light
+    ent = UhomeLightEntity(coord, "light-1")
+    ent.hass = MagicMock()
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_on = True
+    ent._optimistic_set_at = None
+    light.is_on = False  # device disagrees
+
+    ent._handle_coordinator_update()
+    assert ent._optimistic_is_on is True  # held
+    assert ent._optimistic_set_at is not None  # clock started
+
+
 def test_light_onoff_optimism_times_out(coord_with_light):
     coord, light = coord_with_light
     ent = UhomeLightEntity(coord, "light-1")
     ent.hass = MagicMock()
     ent.async_write_ha_state = MagicMock()
     ent._optimistic_is_on = True  # asked for on
+    ent._optimistic_set_at = dt_util.utcnow() - (OPTIMISTIC_TIMEOUT + timedelta(seconds=1))
     light.is_on = False  # device never turns on
 
     ent._handle_coordinator_update()
-    assert ent._optimistic_is_on is True  # clock started, held
-
-    ent._optimistic_set_at = dt_util.utcnow() - (OPTIMISTIC_TIMEOUT + timedelta(seconds=1))
-    ent._handle_coordinator_update()
     assert ent._optimistic_is_on is None
     assert ent.is_on is False
+
+
+async def test_light_commands_stamp_optimistic_set_at(coord_with_light, hass):
+    coord, light = coord_with_light
+    ent = UhomeLightEntity(coord, "light-1")
+    ent.hass = hass
+    ent.entity_id = "light.fake"
+    ent.async_write_ha_state = MagicMock()
+
+    light.is_on = False
+    await ent.async_turn_on()
+    assert ent._optimistic_set_at is not None
+
+    ent._optimistic_set_at = None
+    light.is_on = True
+    await ent.async_turn_off()
+    assert ent._optimistic_set_at is not None
 
 
 def test_light_brightness_optimism_times_out(coord_with_light):
@@ -557,10 +607,25 @@ def test_light_push_onoff_disagreement_clears(coord_with_light):
     ent._optimistic_set_at = dt_util.utcnow()
     light.is_on = False  # push says off
 
-    ent._handle_push_update({"x": 1})
+    ent._handle_push_update(_PUSH_WITH_SWITCH)
     assert ent._optimistic_is_on is None
     assert ent._optimistic_set_at is None
     ent.async_write_ha_state.assert_called_once()
+
+
+def test_light_partial_push_without_switch_state_does_not_clear(coord_with_light):
+    """A push omitting switch state must not clear on/off optimism."""
+    coord, light = coord_with_light
+    ent = UhomeLightEntity(coord, "light-1")
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_on = True
+    stamp = dt_util.utcnow()
+    ent._optimistic_set_at = stamp
+    light.is_on = False  # fallback False from wiped capability
+
+    ent._handle_push_update(_PUSH_NO_SWITCH)
+    assert ent._optimistic_is_on is True  # preserved
+    assert ent._optimistic_set_at == stamp
 
 
 def test_light_push_does_not_clear_brightness(coord_with_light):
@@ -576,7 +641,7 @@ def test_light_push_does_not_clear_brightness(coord_with_light):
     light.brightness = 40  # intermediate ramp value
     ent._optimistic_set_at = dt_util.utcnow()
 
-    ent._handle_push_update({"x": 1})
+    ent._handle_push_update(_PUSH_WITH_SWITCH)
     assert ent._optimistic_brightness == 200  # brightness optimism preserved
     assert ent._pending_brightness_utec == 80
     assert ent._optimistic_set_at is not None  # still outstanding

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,12 +1,16 @@
 """Tests for UhomeLightEntity — init and commands."""
 
+from datetime import timedelta
 from unittest.mock import MagicMock
 
 import pytest
 
+from homeassistant.util import dt as dt_util
+
 from custom_components.u_tec.const import (
     CONF_OPTIMISTIC_LIGHTS,
     DOMAIN,
+    OPTIMISTIC_TIMEOUT,
     SIGNAL_DEVICE_UPDATE,
 )
 from custom_components.u_tec.light import UhomeLightEntity
@@ -486,3 +490,93 @@ def test_handle_push_update_calls_write_ha_state(coord_with_light):
     ent._handle_push_update({"some": "data"})
 
     ent.async_write_ha_state.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Optimistic bounding + push handling (mirrors lock.py; unverified on live
+# hardware). https://github.com/LF2b2w/Uhome-HA/issues/58
+# ---------------------------------------------------------------------------
+
+def test_light_onoff_optimism_times_out(coord_with_light):
+    coord, light = coord_with_light
+    ent = UhomeLightEntity(coord, "light-1")
+    ent.hass = MagicMock()
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_on = True  # asked for on
+    light.is_on = False  # device never turns on
+
+    ent._handle_coordinator_update()
+    assert ent._optimistic_is_on is True  # clock started, held
+
+    ent._optimistic_set_at = dt_util.utcnow() - (OPTIMISTIC_TIMEOUT + timedelta(seconds=1))
+    ent._handle_coordinator_update()
+    assert ent._optimistic_is_on is None
+    assert ent.is_on is False
+
+
+def test_light_brightness_optimism_times_out(coord_with_light):
+    coord, light = coord_with_light
+    ent = UhomeLightEntity(coord, "light-1")
+    ent.hass = MagicMock()
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_on = True
+    light.is_on = True  # on/off confirms
+    ent._optimistic_brightness = 200
+    ent._pending_brightness_utec = 80
+    light.brightness = 40  # device never reaches 80
+    ent._optimistic_set_at = dt_util.utcnow() - (OPTIMISTIC_TIMEOUT + timedelta(seconds=1))
+
+    ent._handle_coordinator_update()
+    assert ent._optimistic_brightness is None
+    assert ent._pending_brightness_utec is None
+    assert ent._optimistic_set_at is None  # nothing outstanding -> clock cleared
+
+
+def test_light_brightness_confirms_normally(coord_with_light):
+    coord, light = coord_with_light
+    ent = UhomeLightEntity(coord, "light-1")
+    ent.hass = MagicMock()
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_on = True
+    light.is_on = True
+    ent._optimistic_brightness = 200
+    ent._pending_brightness_utec = 80
+    light.brightness = 80  # device reached target
+    ent._optimistic_set_at = dt_util.utcnow()
+
+    ent._handle_coordinator_update()
+    assert ent._optimistic_brightness is None
+    assert ent._pending_brightness_utec is None
+
+
+def test_light_push_onoff_disagreement_clears(coord_with_light):
+    coord, light = coord_with_light
+    ent = UhomeLightEntity(coord, "light-1")
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_on = True
+    ent._optimistic_set_at = dt_util.utcnow()
+    light.is_on = False  # push says off
+
+    ent._handle_push_update({"x": 1})
+    assert ent._optimistic_is_on is None
+    assert ent._optimistic_set_at is None
+    ent.async_write_ha_state.assert_called_once()
+
+
+def test_light_push_does_not_clear_brightness(coord_with_light):
+    """A push must not clear optimistic brightness (dimming-ramp values are
+    not authoritative); only on/off is cleared on disagreement."""
+    coord, light = coord_with_light
+    ent = UhomeLightEntity(coord, "light-1")
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_on = True
+    light.is_on = True  # on/off agrees -> not cleared
+    ent._optimistic_brightness = 200
+    ent._pending_brightness_utec = 80
+    light.brightness = 40  # intermediate ramp value
+    ent._optimistic_set_at = dt_util.utcnow()
+
+    ent._handle_push_update({"x": 1})
+    assert ent._optimistic_brightness == 200  # brightness optimism preserved
+    assert ent._pending_brightness_utec == 80
+    assert ent._optimistic_set_at is not None  # still outstanding

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -11,9 +11,13 @@ from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import async_capture_events
 from utec_py.exceptions import DeviceError
 
-from custom_components.u_tec.const import CONF_OPTIMISTIC_LOCKS, DOMAIN, SIGNAL_DEVICE_UPDATE
-from custom_components.u_tec.lock import (
+from custom_components.u_tec.const import (
+    CONF_OPTIMISTIC_LOCKS,
+    DOMAIN,
     OPTIMISTIC_TIMEOUT,
+    SIGNAL_DEVICE_UPDATE,
+)
+from custom_components.u_tec.lock import (
     PASSAGE_MODE,
     UhomeLockEntity,
     async_setup_entry,
@@ -336,6 +340,12 @@ def test_handle_push_update_writes_ha_state(coord_with_lock):
     ent.async_write_ha_state.assert_called_once()
 
 
+# A push payload carrying real lock state, as device.get_state_data() produces.
+_PUSH_WITH_LOCK = {"st.lock": {"lockState": "Locked"}}
+# A partial push that does not carry lock state (e.g. a door-sensor event).
+_PUSH_NO_LOCK = {"st.doorSensor": {"doorState": "open"}}
+
+
 def test_push_disagreement_clears_optimistic_immediately(coord_with_lock):
     """A push that contradicts optimism drops it at once (no 30s wait).
 
@@ -350,11 +360,33 @@ def test_push_disagreement_clears_optimistic_immediately(coord_with_lock):
     ent._optimistic_set_at = dt_util.utcnow()
     lock.is_locked = True  # push already applied: device says locked
 
-    ent._handle_push_update({"some": "data"})
+    ent._handle_push_update(_PUSH_WITH_LOCK)
 
     assert ent._optimistic_is_locked is None
     assert ent._optimistic_set_at is None
     assert ent.is_locked is True  # now reports the pushed truth
+    ent.async_write_ha_state.assert_called_once()
+
+
+def test_partial_push_without_lock_state_does_not_clear(coord_with_lock):
+    """A push that omits lock state must NOT clear optimism.
+
+    Pushes are full-state replaces and Lock.is_locked falls back to False when
+    the lock capability is absent, so a door-sensor/battery push would read as a
+    spurious "unlocked". Optimism must survive it for the confirm/timeout path.
+    """
+    coord, lock = coord_with_lock
+    ent = UhomeLockEntity(coord, "lock-1")
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_locked = True  # user asked for locked
+    stamp = dt_util.utcnow()
+    ent._optimistic_set_at = stamp
+    lock.is_locked = False  # fallback False: capability was wiped by the push
+
+    ent._handle_push_update(_PUSH_NO_LOCK)
+
+    assert ent._optimistic_is_locked is True  # preserved
+    assert ent._optimistic_set_at == stamp
     ent.async_write_ha_state.assert_called_once()
 
 
@@ -368,7 +400,7 @@ def test_push_agreement_keeps_optimistic(coord_with_lock):
     ent._optimistic_set_at = stamp
     lock.is_locked = True  # push agrees
 
-    ent._handle_push_update({"some": "data"})
+    ent._handle_push_update(_PUSH_WITH_LOCK)
 
     assert ent._optimistic_is_locked is True
     assert ent._optimistic_set_at == stamp
@@ -382,10 +414,52 @@ def test_push_with_no_outstanding_optimism_is_noop_but_writes(coord_with_lock):
     ent.async_write_ha_state = MagicMock()
     assert ent._optimistic_is_locked is None
 
-    ent._handle_push_update({"some": "data"})
+    ent._handle_push_update(_PUSH_WITH_LOCK)
 
     assert ent._optimistic_is_locked is None
     ent.async_write_ha_state.assert_called_once()
+
+
+async def test_async_lock_stamps_optimistic_set_at(coord_with_lock, hass):
+    """A command must record when optimism started, so the timeout can bound it."""
+    coord, lock = coord_with_lock
+    lock.is_locked = False
+    ent = UhomeLockEntity(coord, "lock-1")
+    ent.hass = hass
+    ent.entity_id = "lock.fake_lock"
+    ent.async_write_ha_state = MagicMock()
+
+    await ent.async_lock()
+    assert ent._optimistic_set_at is not None
+
+
+async def test_async_unlock_stamps_optimistic_set_at(coord_with_lock, hass):
+    coord, lock = coord_with_lock
+    lock.is_locked = True
+    ent = UhomeLockEntity(coord, "lock-1")
+    ent.hass = hass
+    ent.entity_id = "lock.fake_lock"
+    ent.async_write_ha_state = MagicMock()
+
+    await ent.async_unlock()
+    assert ent._optimistic_set_at is not None
+
+
+def test_confirm_clears_stamp_so_next_command_gets_fresh_clock(coord_with_lock):
+    """On confirmation the stamp must clear, or a later un-stamped optimistic
+    value would inherit a stale start time and time out prematurely."""
+    coord, lock = coord_with_lock
+    ent = UhomeLockEntity(coord, "lock-1")
+    ent.hass = MagicMock()
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_locked = True
+    ent._optimistic_set_at = dt_util.utcnow()
+    lock.is_locked = True  # device confirms
+
+    ent._handle_coordinator_update()
+
+    assert ent._optimistic_is_locked is None
+    assert ent._optimistic_set_at is None
 
 
 # ---------------------------------------------------------------------------
@@ -540,7 +614,6 @@ def test_entering_passage_mode_drops_outstanding_optimism(coord_with_lock):
     assert ent._optimistic_is_locked is None
     assert ent.is_locked is True  # device truth
     assert ent.assumed_state is False
-    assert ent.is_locked == (not ent.assumed_state or ent.is_locked)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,14 +1,23 @@
 """Tests for UhomeLockEntity."""
 
+from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from homeassistant.const import EVENT_STATE_CHANGED
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import async_capture_events
 from utec_py.exceptions import DeviceError
 
 from custom_components.u_tec.const import CONF_OPTIMISTIC_LOCKS, DOMAIN, SIGNAL_DEVICE_UPDATE
-from custom_components.u_tec.lock import UhomeLockEntity, async_setup_entry
+from custom_components.u_tec.lock import (
+    OPTIMISTIC_TIMEOUT,
+    PASSAGE_MODE,
+    UhomeLockEntity,
+    async_setup_entry,
+)
 from tests.common import make_config_entry, make_fake_lock, make_fake_switch
 
 
@@ -325,3 +334,253 @@ def test_handle_push_update_writes_ha_state(coord_with_lock):
     ent._handle_push_update({"some": "data"})
 
     ent.async_write_ha_state.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Optimistic state must not pin forever when the device never confirms
+# ---------------------------------------------------------------------------
+
+async def test_optimistic_clears_once_device_confirms(coord_with_lock, hass):
+    """The happy path: optimistic state is released when the device agrees."""
+    coord, lock = coord_with_lock
+    lock.is_locked = False
+    ent = UhomeLockEntity(coord, "lock-1")
+    ent.hass = hass
+    ent.entity_id = "lock.fake_lock"
+    ent.async_write_ha_state = MagicMock()
+
+    await ent.async_lock()
+    assert ent.is_locked is True  # optimistic
+    assert ent.assumed_state is True
+
+    lock.is_locked = True  # device catches up
+    ent._handle_coordinator_update()
+
+    assert ent._optimistic_is_locked is None
+    assert ent.is_locked is True
+    assert ent.assumed_state is False
+
+
+async def test_optimistic_times_out_when_device_never_confirms(coord_with_lock, hass):
+    """Regression: an unconfirmed optimistic state must not pin forever.
+
+    A lever lock with auto-lock enabled re-locks itself immediately after an
+    unlock, so the device never reports "unlocked" and the entity previously
+    stayed wrong indefinitely.
+    """
+    coord, lock = coord_with_lock
+    lock.is_locked = True
+    ent = UhomeLockEntity(coord, "lock-1")
+    ent.hass = hass
+    ent.entity_id = "lock.fake_lock"
+    ent.async_write_ha_state = MagicMock()
+
+    await ent.async_unlock()
+    assert ent.is_locked is False  # optimistic: we asked for unlocked
+
+    # Device never reports unlocked (auto-lock re-locked it).
+    ent._handle_coordinator_update()
+    assert ent._optimistic_is_locked is False  # still held, within grace
+
+    # Push the stamp beyond the timeout.
+    ent._optimistic_set_at = dt_util.utcnow() - (
+        OPTIMISTIC_TIMEOUT + timedelta(seconds=1)
+    )
+    ent._handle_coordinator_update()
+
+    assert ent._optimistic_is_locked is None
+    assert ent.is_locked is True  # deferred to the device
+    assert ent.assumed_state is False
+
+
+def test_missing_stamp_starts_the_clock_rather_than_clearing(coord_with_lock):
+    """An optimistic value with no timestamp must not be dropped on sight.
+
+    Clearing immediately would destroy the grace period that lets a slow bolt
+    finish moving. Start the clock instead, so the timeout still bounds it.
+    """
+    coord, lock = coord_with_lock
+    lock.is_locked = True
+    ent = UhomeLockEntity(coord, "lock-1")
+    ent.hass = MagicMock()
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_locked = False
+    ent._optimistic_set_at = None
+
+    ent._handle_coordinator_update()
+
+    assert ent._optimistic_is_locked is False, "optimistic value must be held"
+    assert ent._optimistic_set_at is not None, "clock must have been started"
+
+    # It must still time out from that stamp.
+    ent._optimistic_set_at = dt_util.utcnow() - (
+        OPTIMISTIC_TIMEOUT + timedelta(seconds=1)
+    )
+    ent._handle_coordinator_update()
+    assert ent._optimistic_is_locked is None
+
+
+# ---------------------------------------------------------------------------
+# Passage mode ignores lock commands, so optimism there is always wrong
+# ---------------------------------------------------------------------------
+
+def test_is_optimistic_false_in_passage_mode(coord_with_lock):
+    coord, lock = coord_with_lock
+    lock.lock_mode = PASSAGE_MODE
+    ent = UhomeLockEntity(coord, "lock-1")
+
+    assert ent._is_optimistic() is False
+
+
+def test_is_optimistic_true_in_normal_mode(coord_with_lock):
+    coord, lock = coord_with_lock
+    lock.lock_mode = "Normal"
+    ent = UhomeLockEntity(coord, "lock-1")
+
+    assert ent._is_optimistic() is True
+
+
+def test_is_optimistic_unaffected_by_unknown_lock_mode(coord_with_lock):
+    """utec_py returns None when lockMode is missing or unmapped; fail open."""
+    coord, lock = coord_with_lock
+    lock.lock_mode = None
+    ent = UhomeLockEntity(coord, "lock-1")
+
+    assert ent._is_optimistic() is True
+
+
+async def test_passage_mode_lock_does_not_set_optimistic(coord_with_lock, hass):
+    coord, lock = coord_with_lock
+    lock.lock_mode = PASSAGE_MODE
+    lock.is_locked = False
+    ent = UhomeLockEntity(coord, "lock-1")
+    ent.hass = hass
+    ent.entity_id = "lock.fake_lock"
+    ent.async_write_ha_state = MagicMock()
+
+    await ent.async_lock()
+
+    lock.lock.assert_awaited_once()
+    assert ent._optimistic_is_locked is None
+    assert ent.is_locked is False  # the truth: passage mode did not lock
+
+
+def test_entering_passage_mode_drops_outstanding_optimism(coord_with_lock):
+    """Optimism from before the mode changed must not survive into Passage.
+
+    _is_optimistic() reports False in Passage, so a retained optimistic value
+    would make is_locked return an assumed value while assumed_state claims it
+    is confirmed.
+    """
+    coord, lock = coord_with_lock
+    lock.is_locked = True
+    lock.lock_mode = "Normal"
+    ent = UhomeLockEntity(coord, "lock-1")
+    ent.hass = MagicMock()
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_locked = False  # user asked for unlocked
+    ent._optimistic_set_at = dt_util.utcnow()
+
+    # Device flips to Passage before confirming.
+    lock.lock_mode = PASSAGE_MODE
+    ent._handle_coordinator_update()
+
+    assert ent._optimistic_is_locked is None
+    assert ent.is_locked is True  # device truth
+    assert ent.assumed_state is False
+    assert ent.is_locked == (not ent.assumed_state or ent.is_locked)
+
+
+# ---------------------------------------------------------------------------
+# Passage-mode lock commands must still notify listeners (HomeKit resync)
+# ---------------------------------------------------------------------------
+
+async def test_passage_mode_lock_resyncs_listeners(coord_with_lock, hass):
+    """A passage-mode lock command changes nothing, so nothing would notify
+    listeners. HA's HomeKit bridge only recomputes its target characteristic
+    on a state event, so without one the tile hangs on "Locking...".
+    Re-assert the unchanged state with force_update so an event still fires.
+    """
+    coord, lock = coord_with_lock
+    lock.lock_mode = PASSAGE_MODE
+    lock.is_locked = False
+    ent = UhomeLockEntity(coord, "lock-1")
+    ent.hass = hass
+    ent.entity_id = "lock.fake_lock"
+
+    seen_force = []
+    ent.async_write_ha_state = MagicMock(
+        side_effect=lambda: seen_force.append(ent.force_update)
+    )
+
+    await ent.async_lock()
+
+    ent.async_write_ha_state.assert_called_once()
+    assert seen_force == [True], "state must be written with force_update set"
+    assert ent.force_update is False, "force_update must be reset after the write"
+
+
+async def test_normal_mode_lock_does_not_force_update(coord_with_lock, hass):
+    """Normal mode already produces a real state change; no forcing needed."""
+    coord, lock = coord_with_lock
+    lock.lock_mode = "Normal"
+    lock.is_locked = False
+    ent = UhomeLockEntity(coord, "lock-1")
+    ent.hass = hass
+    ent.entity_id = "lock.fake_lock"
+
+    seen_force = []
+    ent.async_write_ha_state = MagicMock(
+        side_effect=lambda: seen_force.append(ent.force_update)
+    )
+
+    await ent.async_lock()
+
+    assert seen_force == [False]
+
+
+async def test_force_update_reset_even_if_write_raises(coord_with_lock, hass):
+    """force_update must not leak on if the write blows up."""
+    coord, lock = coord_with_lock
+    lock.lock_mode = PASSAGE_MODE
+    ent = UhomeLockEntity(coord, "lock-1")
+    ent.hass = hass
+    ent.entity_id = "lock.fake_lock"
+    ent.async_write_ha_state = MagicMock(side_effect=RuntimeError("boom"))
+
+    with pytest.raises(RuntimeError):
+        await ent.async_lock()
+
+    assert ent.force_update is False
+
+
+async def test_passage_mode_lock_emits_real_state_event(coord_with_lock, hass):
+    """Integration-level: the forced write must reach the state machine.
+
+    The unit tests above mock async_write_ha_state, so they only prove the
+    force_update choreography. This one drives the real state machine and
+    asserts a state_changed event actually fires for an identical state --
+    the property the HomeKit resync depends on.
+    """
+    coord, lock = coord_with_lock
+    lock.lock_mode = PASSAGE_MODE
+    lock.is_locked = False
+    ent = UhomeLockEntity(coord, "lock-1")
+    ent.hass = hass
+    ent.entity_id = "lock.fake_lock"
+
+    # Seed the machine with this entity's own state and attributes, so the
+    # write under test is byte-identical and would normally be suppressed.
+    ent.async_write_ha_state()
+    await hass.async_block_till_done()
+    before = hass.states.get("lock.fake_lock")
+    assert before is not None
+
+    events = async_capture_events(hass, EVENT_STATE_CHANGED)
+
+    await ent.async_lock()
+    await hass.async_block_till_done()
+
+    matching = [e for e in events if e.data["entity_id"] == "lock.fake_lock"]
+    assert matching, "an identical state must still emit state_changed when forced"
+    assert matching[0].data["new_state"].state == before.state

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -336,6 +336,58 @@ def test_handle_push_update_writes_ha_state(coord_with_lock):
     ent.async_write_ha_state.assert_called_once()
 
 
+def test_push_disagreement_clears_optimistic_immediately(coord_with_lock):
+    """A push that contradicts optimism drops it at once (no 30s wait).
+
+    The #58 case: user unlocked (optimistic=unlocked), auto-lock re-locked the
+    device, and the device pushes "locked". The coordinator has already applied
+    the push, so _device.is_locked is True.
+    """
+    coord, lock = coord_with_lock
+    ent = UhomeLockEntity(coord, "lock-1")
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_locked = False  # user asked for unlocked
+    ent._optimistic_set_at = dt_util.utcnow()
+    lock.is_locked = True  # push already applied: device says locked
+
+    ent._handle_push_update({"some": "data"})
+
+    assert ent._optimistic_is_locked is None
+    assert ent._optimistic_set_at is None
+    assert ent.is_locked is True  # now reports the pushed truth
+    ent.async_write_ha_state.assert_called_once()
+
+
+def test_push_agreement_keeps_optimistic(coord_with_lock):
+    """A push that agrees with optimism leaves it for the confirm/timeout path."""
+    coord, lock = coord_with_lock
+    ent = UhomeLockEntity(coord, "lock-1")
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_locked = True
+    stamp = dt_util.utcnow()
+    ent._optimistic_set_at = stamp
+    lock.is_locked = True  # push agrees
+
+    ent._handle_push_update({"some": "data"})
+
+    assert ent._optimistic_is_locked is True
+    assert ent._optimistic_set_at == stamp
+    ent.async_write_ha_state.assert_called_once()
+
+
+def test_push_with_no_outstanding_optimism_is_noop_but_writes(coord_with_lock):
+    """No optimism outstanding: push just writes, touches nothing."""
+    coord, lock = coord_with_lock
+    ent = UhomeLockEntity(coord, "lock-1")
+    ent.async_write_ha_state = MagicMock()
+    assert ent._optimistic_is_locked is None
+
+    ent._handle_push_update({"some": "data"})
+
+    assert ent._optimistic_is_locked is None
+    ent.async_write_ha_state.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # Optimistic state must not pin forever when the device never confirms
 # ---------------------------------------------------------------------------

--- a/tests/test_optimistic.py
+++ b/tests/test_optimistic.py
@@ -1,12 +1,33 @@
 """Unit tests for the optimistic-update resolver."""
 
+import pytest
+
 from custom_components.u_tec.optimistic import (
     CONF_OPTIMISTIC_LIGHTS,
     CONF_OPTIMISTIC_LOCKS,
     CONF_OPTIMISTIC_SWITCHES,
     DEFAULT_OPTIMISTIC,
     is_optimistic_enabled,
+    push_asserts_state,
 )
+
+
+@pytest.mark.parametrize(
+    "push_data,expected",
+    [
+        ({"st.lock": {"lockState": "Locked"}}, True),  # capability + attr present
+        ({"st.lock": {"lockState": "Unlocked"}}, True),  # value doesn't matter
+        ({"st.doorSensor": {"doorState": "open"}}, False),  # different capability
+        ({"st.lock": {"battery": 3}}, False),  # capability present, wrong attr
+        ({"st.lock": {}}, False),  # capability present, no attrs
+        ({}, False),  # empty
+        (None, False),  # not a dict
+        ("garbage", False),  # not a dict
+        ({"st.lock": "notadict"}, False),  # capability value isn't a dict
+    ],
+)
+def test_push_asserts_state(push_data, expected):
+    assert push_asserts_state(push_data, "st.lock", "lockState") is expected
 
 
 def test_default_constant_is_true():

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,10 +1,18 @@
 """Tests for UhomeSwitchEntity."""
 
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from custom_components.u_tec.const import CONF_OPTIMISTIC_SWITCHES, DOMAIN, SIGNAL_DEVICE_UPDATE
+from homeassistant.util import dt as dt_util
+
+from custom_components.u_tec.const import (
+    CONF_OPTIMISTIC_SWITCHES,
+    DOMAIN,
+    OPTIMISTIC_TIMEOUT,
+    SIGNAL_DEVICE_UPDATE,
+)
 from custom_components.u_tec.switch import UhomeSwitchEntity
 from tests.common import make_config_entry, make_fake_lock, make_fake_switch
 
@@ -306,3 +314,65 @@ async def test_async_added_to_hass_registers_dispatcher(coord_with_switch, hass)
     call_args = mock_connect.call_args
     signal = call_args[0][1]
     assert signal == f"{SIGNAL_DEVICE_UPDATE}_sw-1"
+
+
+# ---------------------------------------------------------------------------
+# Optimistic state must not pin forever; push disagreement clears immediately
+# (mirrors lock.py; see https://github.com/LF2b2w/Uhome-HA/issues/58)
+# ---------------------------------------------------------------------------
+
+def test_switch_optimistic_times_out_when_never_confirmed(coord_with_switch):
+    coord, sw = coord_with_switch
+    ent = UhomeSwitchEntity(coord, "sw-1")
+    ent.hass = MagicMock()
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_on = True  # asked for on
+    sw.is_on = False  # device never turns on
+
+    ent._handle_coordinator_update()
+    assert ent._optimistic_is_on is True  # held (clock just started)
+
+    ent._optimistic_set_at = dt_util.utcnow() - (OPTIMISTIC_TIMEOUT + timedelta(seconds=1))
+    ent._handle_coordinator_update()
+    assert ent._optimistic_is_on is None
+    assert ent.is_on is False  # deferred to device
+
+
+def test_switch_optimistic_held_during_grace(coord_with_switch):
+    coord, sw = coord_with_switch
+    ent = UhomeSwitchEntity(coord, "sw-1")
+    ent.hass = MagicMock()
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_on = True
+    ent._optimistic_set_at = dt_util.utcnow()
+    sw.is_on = False
+
+    ent._handle_coordinator_update()
+    assert ent._optimistic_is_on is True  # within grace
+
+
+def test_switch_push_disagreement_clears(coord_with_switch):
+    coord, sw = coord_with_switch
+    ent = UhomeSwitchEntity(coord, "sw-1")
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_on = True
+    ent._optimistic_set_at = dt_util.utcnow()
+    sw.is_on = False  # push applied: device says off
+
+    ent._handle_push_update({"x": 1})
+    assert ent._optimistic_is_on is None
+    assert ent._optimistic_set_at is None
+    assert ent.is_on is False
+    ent.async_write_ha_state.assert_called_once()
+
+
+def test_switch_push_agreement_keeps(coord_with_switch):
+    coord, sw = coord_with_switch
+    ent = UhomeSwitchEntity(coord, "sw-1")
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_on = True
+    ent._optimistic_set_at = dt_util.utcnow()
+    sw.is_on = True  # push agrees
+
+    ent._handle_push_update({"x": 1})
+    assert ent._optimistic_is_on is True

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -321,6 +321,11 @@ async def test_async_added_to_hass_registers_dispatcher(coord_with_switch, hass)
 # (mirrors lock.py; see https://github.com/LF2b2w/Uhome-HA/issues/58)
 # ---------------------------------------------------------------------------
 
+# A push payload carrying real switch state, and one that omits it.
+_PUSH_WITH_SWITCH = {"st.switch": {"switch": "on"}}
+_PUSH_NO_SWITCH = {"st.batteryLevel": {"level": 3}}
+
+
 def test_switch_optimistic_times_out_when_never_confirmed(coord_with_switch):
     coord, sw = coord_with_switch
     ent = UhomeSwitchEntity(coord, "sw-1")
@@ -330,7 +335,8 @@ def test_switch_optimistic_times_out_when_never_confirmed(coord_with_switch):
     sw.is_on = False  # device never turns on
 
     ent._handle_coordinator_update()
-    assert ent._optimistic_is_on is True  # held (clock just started)
+    assert ent._optimistic_is_on is True  # held
+    assert ent._optimistic_set_at is not None  # clock was started
 
     ent._optimistic_set_at = dt_util.utcnow() - (OPTIMISTIC_TIMEOUT + timedelta(seconds=1))
     ent._handle_coordinator_update()
@@ -359,11 +365,26 @@ def test_switch_push_disagreement_clears(coord_with_switch):
     ent._optimistic_set_at = dt_util.utcnow()
     sw.is_on = False  # push applied: device says off
 
-    ent._handle_push_update({"x": 1})
+    ent._handle_push_update(_PUSH_WITH_SWITCH)
     assert ent._optimistic_is_on is None
     assert ent._optimistic_set_at is None
     assert ent.is_on is False
     ent.async_write_ha_state.assert_called_once()
+
+
+def test_switch_partial_push_without_switch_state_does_not_clear(coord_with_switch):
+    """A push omitting switch state must not clear optimism (fallback-False)."""
+    coord, sw = coord_with_switch
+    ent = UhomeSwitchEntity(coord, "sw-1")
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_on = True
+    stamp = dt_util.utcnow()
+    ent._optimistic_set_at = stamp
+    sw.is_on = False  # fallback False from the wiped capability
+
+    ent._handle_push_update(_PUSH_NO_SWITCH)
+    assert ent._optimistic_is_on is True  # preserved
+    assert ent._optimistic_set_at == stamp
 
 
 def test_switch_push_agreement_keeps(coord_with_switch):
@@ -371,8 +392,42 @@ def test_switch_push_agreement_keeps(coord_with_switch):
     ent = UhomeSwitchEntity(coord, "sw-1")
     ent.async_write_ha_state = MagicMock()
     ent._optimistic_is_on = True
-    ent._optimistic_set_at = dt_util.utcnow()
+    stamp = dt_util.utcnow()
+    ent._optimistic_set_at = stamp
     sw.is_on = True  # push agrees
 
-    ent._handle_push_update({"x": 1})
+    ent._handle_push_update(_PUSH_WITH_SWITCH)
     assert ent._optimistic_is_on is True
+    assert ent._optimistic_set_at == stamp  # stamp preserved
+
+
+def test_switch_missing_stamp_starts_clock(coord_with_switch):
+    """Optimism set without a stamp must start the clock, not clear on sight."""
+    coord, sw = coord_with_switch
+    ent = UhomeSwitchEntity(coord, "sw-1")
+    ent.hass = MagicMock()
+    ent.async_write_ha_state = MagicMock()
+    ent._optimistic_is_on = True
+    ent._optimistic_set_at = None
+    sw.is_on = False  # device disagrees
+
+    ent._handle_coordinator_update()
+    assert ent._optimistic_is_on is True  # held
+    assert ent._optimistic_set_at is not None  # clock started
+
+
+async def test_switch_commands_stamp_optimistic_set_at(coord_with_switch, hass):
+    coord, sw = coord_with_switch
+    ent = UhomeSwitchEntity(coord, "sw-1")
+    ent.hass = hass
+    ent.entity_id = "switch.fake"
+    ent.async_write_ha_state = MagicMock()
+
+    sw.is_on = False
+    await ent.async_turn_on()
+    assert ent._optimistic_set_at is not None
+
+    ent._optimistic_set_at = None
+    sw.is_on = True
+    await ent.async_turn_off()
+    assert ent._optimistic_set_at is not None


### PR DESCRIPTION
Fixes three related defects in optimistic lock handling. All three were observed on real hardware — an ULTRALOQ **Latch-5-F** (lever lock) — and each is covered by tests.

`Refs #58` rather than `Fixes`, because that issue also covers `light.py` and `switch.py`; see **Scope** below.

---

### 1. Optimistic state could pin forever

`_handle_coordinator_update` cleared `_optimistic_is_locked` only when the device confirmed the exact commanded state, with no give-up path. If the device never reports that state, the entity stays wrong indefinitely.

This isn't hypothetical. **Auto-lock cannot be disabled on ULTRALOQ lever locks** — U-tec staff have confirmed this; only the delay is adjustable (max 5 min). So the lock re-locks itself moments after any unlock, the device never reports `unlocked`, and an unlock command pinned the entity on `unlocked` **while the door was locked** — permanently, until HA restarted.

Observed: HA's recorded state stayed `unlocked` for minutes while `Uhome.Device`/`Query` returned `lockState: Locked` continuously. The 10s poll was healthy throughout; its data was simply being overridden.

Optimism is now held for `OPTIMISTIC_TIMEOUT` (30s), then released to the device.

- **Why 30s:** ≈3 polls at the default `DEFAULT_SCAN_INTERVAL = 10`, preserving the grace period the original docstring describes (letting a slow bolt finish moving) without waiting forever.
- The effective bound is `max(timeout, time-to-next-update)`, since it's only evaluated on a coordinator update. With a `scan_interval` above 30s the grace period degrades toward "cleared at the first disagreeing poll".
- An optimistic value with **no timestamp** starts the clock rather than being dropped, so the grace period is never lost. (Clearing on sight would break the existing `test_handle_coordinator_update_keeps_optimistic_when_unconfirmed`, which is correct to assert what it does.)

### 2. Optimism was applied in Passage mode, where it's always wrong

In Passage mode (`lockMode == 1`, which `utec_py` maps to `"Passage"`) the device ignores lock/unlock commands outright. An optimistic value can never be confirmed there and would burn the full timeout before self-correcting.

`_is_optimistic()` now returns `False` in that mode. Optimism outstanding from *before* the mode changed is dropped on the next coordinator update — otherwise `is_locked` would return an assumed value while `assumed_state` reported it as confirmed, since `assumed_state` calls `_is_optimistic()`.

`lock_mode` returns `None` when the state is missing or unmapped; `None == "Passage"` is `False`, so unknown modes fall through to existing behaviour (fail-open).

### 3. A Passage-mode lock command left consumers stuck

With (2), such a command changes nothing, so **no state event fires**. Consumers that recompute only on a state change never learn the command was a no-op.

Concretely: HA's HomeKit bridge recomputes its lock target characteristic in `homekit/type_locks.py::async_update_state`, which runs only from `async_update_event_state_callback` on a state event. With no event, HomeKit's target stayed at the value the Home app wrote when the user tapped lock while current stayed `unlocked` — and the tile hung on **"Locking…" indefinitely**.

`async_lock` now re-asserts the unchanged **true** state with `force_update` set, emitting a real state event without publishing anything false.

`async_unlock` deliberately has no counterpart: a lock in Passage mode already reports itself unlocked, so target and current agree and nothing can hang. Only the lock direction can diverge.

**On the `force_update` mechanism:** `Entity._async_write_ha_state` passes `force_update` positionally into `states.async_set_internal`; `core.py` computes `same_state = old_state.state == new_state and not force_update`, so a forced identical write does emit `EVENT_STATE_CHANGED`. It's read in exactly one place in HA core and isn't cached at registration, so toggling it around a single write is safe. Verified against current HA source. It is an implicit behaviour, not a contractual API, so it needs a maintainer's eye.

---

### Scope

**`light.py` and `switch.py` are deliberately not fixed here**, though they share the identical unbounded-optimism pattern (`switch.py:94-96`, `light.py:158-168` — same `# else: keep optimistic state until device catches up`, no timeout). A light or switch whose command silently fails pins the same way.

They're left alone because this fix is scoped to the platform whose failure was actually **reproduced on hardware**. Extending it to lights and switches is mechanical, but I have neither device and would be extrapolating rather than verifying. That's noted in a comment at `OPTIMISTIC_TIMEOUT` so the omission is deliberate and visible rather than an oversight. Happy to extend this PR if you'd prefer it in one go.

### Tests

12 new tests in `tests/test_lock.py`; **34 pass** (22 existing + 12 new). No existing test changed.

Includes `test_passage_mode_lock_emits_real_state_event`, an integration-level test that drives the real state machine and asserts a forced identical write emits `state_changed` — the property (3) depends on. The other resync tests mock `async_write_ha_state` and would otherwise only prove the flag choreography.

All new tests were mutation-tested: reverting each fix individually causes the corresponding test to fail.

### Notes

- `custom_components/u_tec/lock.py` is black-clean. I did **not** run black across `tests/test_lock.py`, as the file isn't currently black-formatted and doing so produced ~12 blank-line-only hunks in code this PR doesn't touch. New test code is written black-compatible by hand.
- `tests/test_oauth.py` and `tests/test_oauth_wiring.py` fail on **clean `main`** under Python 3.14 (an `aioresponses`/`aiohttp` `ClientResponse.__init__()` incompatibility). Unrelated to this PR; CI pins 3.12, where they pass.
