### PR TITLE
Feature/cloudhook support

### DIFF
--- a/custom_components/u_tec/api.py
+++ b/custom_components/u_tec/api.py
@@ -206,6 +206,34 @@ class AsyncPushUpdateHandler:
             self._unregister_webhook = None
             _LOGGER.debug("Unregistered webhook %s", self.webhook_id)
 
+    async def _parse_request_body(self, request) -> dict:
+        """Parse JSON body from either aiohttp Request or cloud MockRequest.
+
+        Nabu Casa cloudhooks deliver a MockRequest that exposes ``json()`` but
+        not ``read()``. Local webhook deliveries use a full aiohttp Request
+        with both. Prefer ``json()`` when available; fall back to ``read()``.
+        """
+        # Prefer json() — works for cloud MockRequest and aiohttp Request.
+        json_method = getattr(request, "json", None)
+        if callable(json_method):
+            try:
+                data = await json_method()
+                if isinstance(data, dict):
+                    return data
+            except Exception:  # noqa: BLE001
+                # Fall through to read() path.
+                pass
+
+        read_method = getattr(request, "read", None)
+        if callable(read_method):
+            raw_body = await read_method()
+            if isinstance(raw_body, bytes):
+                return json.loads(raw_body)
+            if isinstance(raw_body, str):
+                return json.loads(raw_body)
+
+        raise ValueError("Request body is not valid JSON")
+
     async def _handle_webhook(
         self, hass: HomeAssistant, webhook_id, request
     ) -> web.Response | None:
@@ -215,19 +243,18 @@ class AsyncPushUpdateHandler:
                 _LOGGER.error("Unsupported method: %s", request.method)
                 return web.Response(status=405)
 
-            raw_body = await request.read()
-            _LOGGER.debug(
-                "Webhook hit received: method=%s headers=%s body=%s",
-                request.method,
-                dict(request.headers),
-                raw_body.decode("utf-8", errors="replace"),
-            )
-
             try:
-                data = json.loads(raw_body)
+                data = await self._parse_request_body(request)
             except Exception as json_err:  # noqa: BLE001
                 _LOGGER.error("Failed to parse webhook JSON: %s", json_err)
                 return web.Response(status=400)
+
+            _LOGGER.debug(
+                "Webhook hit received: method=%s headers=%s data=%s",
+                request.method,
+                dict(getattr(request, "headers", {}) or {}),
+                data,
+            )
 
             # Validate the push secret via the Authorization header.
             # U-Tec sends it as "Bearer <access_token>" in the HTTP header.
@@ -238,7 +265,9 @@ class AsyncPushUpdateHandler:
                     "Webhook received before push secret was initialised -- rejecting"
                 )
                 return web.Response(status=401)
-            auth_header = request.headers.get("Authorization", "")
+            auth_header = (getattr(request, "headers", {}) or {}).get(
+                "Authorization", ""
+            )
             incoming_token = auth_header.removeprefix("Bearer ").strip()
             if not incoming_token:
                 _LOGGER.warning(

--- a/custom_components/u_tec/api.py
+++ b/custom_components/u_tec/api.py
@@ -61,33 +61,44 @@ class AsyncPushUpdateHandler:
         """Generate a fresh random secret token for push validation."""
         return secrets.token_urlsafe(32)
 
+    async def _try_get_cloudhook_url(self) -> str | None:
+        """Return a Nabu Casa cloudhook URL if Cloud is active, else None.
+
+        Cloud is imported lazily so loading this module does not pull in the
+        full Cloud → Alexa → camera dependency chain. Unit tests patch this
+        method instead of importing homeassistant.components.cloud.
+        """
+        from homeassistant.components import cloud
+
+        if not cloud.async_active_subscription(self.hass):
+            return None
+
+        try:
+            webhook_url = await cloud.async_get_or_create_cloudhook(
+                self.hass, self.webhook_id
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning(
+                "Cloudhook creation failed, falling back to external URL: %s",
+                err,
+            )
+            return None
+
+        if webhook_url:
+            _LOGGER.debug("Using Nabu Casa cloudhook: %s", webhook_url)
+        return webhook_url or None
+
     async def _resolve_webhook_url(self) -> str | None:
         """Resolve an externally-reachable webhook URL.
 
         Prefer a Nabu Casa cloudhook when Home Assistant Cloud is active.
         Otherwise fall back through network.get_url strategies.
-
-        Cloud is imported lazily so loading this module does not pull in the
-        full Cloud → Alexa → camera dependency chain (needed for unit tests
-        and lighter HA startup).
         """
         # 1. Prefer a real cloudhook when Nabu Casa is active.
-        from homeassistant.components import cloud
-
-        if cloud.async_active_subscription(self.hass):
-            try:
-                webhook_url = await cloud.async_get_or_create_cloudhook(
-                    self.hass, self.webhook_id
-                )
-                if webhook_url:
-                    self._used_cloudhook = True
-                    _LOGGER.debug("Using Nabu Casa cloudhook: %s", webhook_url)
-                    return webhook_url
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.warning(
-                    "Cloudhook creation failed, falling back to external URL: %s",
-                    err,
-                )
+        cloudhook_url = await self._try_get_cloudhook_url()
+        if cloudhook_url:
+            self._used_cloudhook = True
+            return cloudhook_url
 
         self._used_cloudhook = False
 

--- a/custom_components/u_tec/api.py
+++ b/custom_components/u_tec/api.py
@@ -88,6 +88,27 @@ class AsyncPushUpdateHandler:
             _LOGGER.debug("Using Nabu Casa cloudhook: %s", webhook_url)
         return webhook_url or None
 
+    async def _delete_cloudhook(self) -> None:
+        """Best-effort delete of any Nabu Casa cloudhook for this webhook_id.
+
+        Always attempted on unregister (idempotent) so a cloudhook created in a
+        previous process lifetime, or after fallback-then-Cloud-reconnect, is
+        still cleaned up. Lazy-imports cloud to avoid the Alexa/turbojpeg import
+        chain — unit tests patch this method as a seam.
+        """
+        try:
+            from homeassistant.components import cloud
+
+            await cloud.async_delete_cloudhook(self.hass, self.webhook_id)
+            _LOGGER.debug("Deleted cloudhook %s", self.webhook_id)
+        except Exception as err:  # noqa: BLE001
+            # Orphaned hooks on hooks.nabu.casa are otherwise invisible.
+            _LOGGER.warning(
+                "Could not delete cloudhook %s (may already be gone): %s",
+                self.webhook_id,
+                err,
+            )
+
     async def _resolve_webhook_url(self) -> str | None:
         """Resolve an externally-reachable webhook URL.
 
@@ -216,10 +237,12 @@ class AsyncPushUpdateHandler:
     async def unregister_webhook(self) -> None:
         """Unregister the webhook and cancel the re-registration scheduler.
 
-        Also deletes the Nabu Casa cloudhook when one was created. HA's
+        Always attempts cloudhook deletion (idempotent). HA's
         ``webhook.async_unregister`` only removes the local handler; without
-        ``cloud.async_delete_cloudhook`` an orphaned hook remains on
-        hooks.nabu.casa after full config-entry removal.
+        ``cloud.async_delete_cloudhook`` an orphaned hook can remain on
+        hooks.nabu.casa after full config-entry removal. Deletion is not gated
+        on ``_used_cloudhook`` so hooks from a prior process lifetime (or after
+        fallback→Cloud reconnect) are still cleaned up.
         """
         if self._cancel_reregister:
             self._cancel_reregister()
@@ -229,20 +252,8 @@ class AsyncPushUpdateHandler:
             self._unregister_webhook = None
             _LOGGER.debug("Unregistered webhook %s", self.webhook_id)
 
-        if self._used_cloudhook:
-            try:
-                from homeassistant.components import cloud
-
-                await cloud.async_delete_cloudhook(self.hass, self.webhook_id)
-                _LOGGER.debug("Deleted cloudhook %s", self.webhook_id)
-            except Exception as err:  # noqa: BLE001
-                # Tolerate failure (Cloud offline, already deleted, etc.).
-                _LOGGER.debug(
-                    "Could not delete cloudhook %s: %s",
-                    self.webhook_id,
-                    err,
-                )
-            self._used_cloudhook = False
+        await self._delete_cloudhook()
+        self._used_cloudhook = False
 
     async def _parse_request_body(self, request) -> dict | list:
         """Parse JSON body from either aiohttp Request or cloud MockRequest.

--- a/custom_components/u_tec/api.py
+++ b/custom_components/u_tec/api.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 
 from aiohttp import ClientSession, web
 
-from homeassistant.components import webhook
+from homeassistant.components import cloud, webhook
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_entry_oauth2_flow, network
 from homeassistant.helpers.event import async_track_time_interval
@@ -55,16 +55,37 @@ class AsyncPushUpdateHandler:
         self._push_secret: str | None = None
         self.api = api
         self._auth_data = None
+        self._used_cloudhook = False
 
     def _generate_secret(self) -> str:
         """Generate a fresh random secret token for push validation."""
         return secrets.token_urlsafe(32)
 
-    async def async_register_webhook(self, auth_data) -> bool:
-        """Register webhook with Home Assistant and the Uhome API."""
-        self._auth_data = auth_data
+    async def _resolve_webhook_url(self) -> str | None:
+        """Resolve an externally-reachable webhook URL.
 
-        # Try multiple URL resolution strategies
+        Prefer a Nabu Casa cloudhook when Home Assistant Cloud is active.
+        Otherwise fall back through network.get_url strategies.
+        """
+        # 1. Prefer a real cloudhook when Nabu Casa is active.
+        if cloud.async_active_subscription(self.hass):
+            try:
+                webhook_url = await cloud.async_get_or_create_cloudhook(
+                    self.hass, self.webhook_id
+                )
+                if webhook_url:
+                    self._used_cloudhook = True
+                    _LOGGER.debug("Using Nabu Casa cloudhook: %s", webhook_url)
+                    return webhook_url
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.warning(
+                    "Cloudhook creation failed, falling back to external URL: %s",
+                    err,
+                )
+
+        self._used_cloudhook = False
+
+        # 2. Fall back through network.get_url strategies.
         external_url = None
         for allow_internal, allow_ip, prefer_cloud in [
             (False, False, False),
@@ -81,13 +102,26 @@ class AsyncPushUpdateHandler:
                 if external_url:
                     _LOGGER.debug(
                         "Resolved webhook base URL: %s (internal=%s, cloud=%s)",
-                        external_url, allow_internal, prefer_cloud,
+                        external_url,
+                        allow_internal,
+                        prefer_cloud,
                     )
                     break
             except NoURLAvailableError:
                 continue
 
         if not external_url:
+            return None
+
+        return webhook.async_generate_url(self.hass, self.webhook_id)
+
+    async def async_register_webhook(self, auth_data) -> bool:
+        """Register webhook with Home Assistant and the Uhome API."""
+        self._auth_data = auth_data
+
+        webhook_url = await self._resolve_webhook_url()
+
+        if not webhook_url:
             _LOGGER.error(
                 "No external URL available for push notifications. "
                 "Configure an external URL in Settings -> System -> Network, "
@@ -95,11 +129,17 @@ class AsyncPushUpdateHandler:
             )
             return False
 
-        webhook_url = webhook.async_generate_url(self.hass, self.webhook_id)
-
-        if any(local in webhook_url for local in (
-            "192.168.", "10.", "172.", "homeassistant.local", "localhost", "127.0."
-        )):
+        if not self._used_cloudhook and any(
+            local in webhook_url
+            for local in (
+                "192.168.",
+                "10.",
+                "172.",
+                "homeassistant.local",
+                "localhost",
+                "127.0.",
+            )
+        ):
             _LOGGER.warning(
                 "Webhook URL %s appears to be a local address. "
                 "U-Tec's servers cannot reach it -- push state updates will not work. "
@@ -225,6 +265,8 @@ class AsyncPushUpdateHandler:
             return web.json_response({"success": False, "error": str(err)}, status=400)
         except Exception as err:  # noqa: BLE001
             _LOGGER.exception("Unexpected error processing webhook: %s", err)
-            return web.json_response({"success": False, "error": "Internal error"}, status=500)
+            return web.json_response(
+                {"success": False, "error": "Internal error"}, status=500
+            )
         else:
             return web.json_response({"success": True})

--- a/custom_components/u_tec/api.py
+++ b/custom_components/u_tec/api.py
@@ -214,7 +214,13 @@ class AsyncPushUpdateHandler:
         )
 
     async def unregister_webhook(self) -> None:
-        """Unregister the webhook and cancel the re-registration scheduler."""
+        """Unregister the webhook and cancel the re-registration scheduler.
+
+        Also deletes the Nabu Casa cloudhook when one was created. HA's
+        ``webhook.async_unregister`` only removes the local handler; without
+        ``cloud.async_delete_cloudhook`` an orphaned hook remains on
+        hooks.nabu.casa after full config-entry removal.
+        """
         if self._cancel_reregister:
             self._cancel_reregister()
             self._cancel_reregister = None
@@ -222,6 +228,21 @@ class AsyncPushUpdateHandler:
             webhook.async_unregister(self.hass, self.webhook_id)
             self._unregister_webhook = None
             _LOGGER.debug("Unregistered webhook %s", self.webhook_id)
+
+        if self._used_cloudhook:
+            try:
+                from homeassistant.components import cloud
+
+                await cloud.async_delete_cloudhook(self.hass, self.webhook_id)
+                _LOGGER.debug("Deleted cloudhook %s", self.webhook_id)
+            except Exception as err:  # noqa: BLE001
+                # Tolerate failure (Cloud offline, already deleted, etc.).
+                _LOGGER.debug(
+                    "Could not delete cloudhook %s: %s",
+                    self.webhook_id,
+                    err,
+                )
+            self._used_cloudhook = False
 
     async def _parse_request_body(self, request) -> dict | list:
         """Parse JSON body from either aiohttp Request or cloud MockRequest.

--- a/custom_components/u_tec/api.py
+++ b/custom_components/u_tec/api.py
@@ -223,19 +223,22 @@ class AsyncPushUpdateHandler:
             self._unregister_webhook = None
             _LOGGER.debug("Unregistered webhook %s", self.webhook_id)
 
-    async def _parse_request_body(self, request) -> dict:
+    async def _parse_request_body(self, request) -> dict | list:
         """Parse JSON body from either aiohttp Request or cloud MockRequest.
 
         Nabu Casa cloudhooks deliver a MockRequest that exposes ``json()`` but
         not ``read()``. Local webhook deliveries use a full aiohttp Request
         with both. Prefer ``json()`` when available; fall back to ``read()``.
+
+        Accept both object and array top-level JSON — the coordinator already
+        normalises list-shaped U-Tec push payloads (issue #30).
         """
         # Prefer json() — works for cloud MockRequest and aiohttp Request.
         json_method = getattr(request, "json", None)
         if callable(json_method):
             try:
                 data = await json_method()
-                if isinstance(data, dict):
+                if isinstance(data, (dict, list)):
                     return data
             except Exception:  # noqa: BLE001
                 # Fall through to read() path.
@@ -245,9 +248,13 @@ class AsyncPushUpdateHandler:
         if callable(read_method):
             raw_body = await read_method()
             if isinstance(raw_body, bytes):
-                return json.loads(raw_body)
-            if isinstance(raw_body, str):
-                return json.loads(raw_body)
+                data = json.loads(raw_body)
+            elif isinstance(raw_body, str):
+                data = json.loads(raw_body)
+            else:
+                raise ValueError("Request body is not valid JSON")
+            if isinstance(data, (dict, list)):
+                return data
 
         raise ValueError("Request body is not valid JSON")
 

--- a/custom_components/u_tec/api.py
+++ b/custom_components/u_tec/api.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 
 from aiohttp import ClientSession, web
 
-from homeassistant.components import cloud, webhook
+from homeassistant.components import webhook
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_entry_oauth2_flow, network
 from homeassistant.helpers.event import async_track_time_interval
@@ -66,8 +66,14 @@ class AsyncPushUpdateHandler:
 
         Prefer a Nabu Casa cloudhook when Home Assistant Cloud is active.
         Otherwise fall back through network.get_url strategies.
+
+        Cloud is imported lazily so loading this module does not pull in the
+        full Cloud → Alexa → camera dependency chain (needed for unit tests
+        and lighter HA startup).
         """
         # 1. Prefer a real cloudhook when Nabu Casa is active.
+        from homeassistant.components import cloud
+
         if cloud.async_active_subscription(self.hass):
             try:
                 webhook_url = await cloud.async_get_or_create_cloudhook(

--- a/custom_components/u_tec/manifest.json
+++ b/custom_components/u_tec/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "u_tec",
   "name": "U-Tec",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "codeowners": [
     "@LF2b2w",
     "@rbridal"

--- a/custom_components/u_tec/manifest.json
+++ b/custom_components/u_tec/manifest.json
@@ -1,17 +1,18 @@
 {
   "domain": "u_tec",
   "name": "U-Tec",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "codeowners": [
-    "@LF2b2w"
+    "@LF2b2w",
+    "@rbridal"
   ],
   "config_flow": true,
   "dependencies": [
     "application_credentials",
     "diagnostics"
   ],
-  "documentation": "https://github.com/LF2b2w/Uhome-HA",
-  "issue_tracker": "https://github.com/LF2b2w/Uhome-HA/issues",
+  "documentation": "https://github.com/rbridal/Uhome-HA",
+  "issue_tracker": "https://github.com/rbridal/Uhome-HA/issues",
   "iot_class": "cloud_polling",
   "requirements": [
     "utec_py_LF2b2w==0.4.0"

--- a/custom_components/u_tec/manifest.json
+++ b/custom_components/u_tec/manifest.json
@@ -1,18 +1,17 @@
 {
   "domain": "u_tec",
   "name": "U-Tec",
-  "version": "0.4.2",
+  "version": "0.4.0",
   "codeowners": [
-    "@LF2b2w",
-    "@rbridal"
+    "@LF2b2w"
   ],
   "config_flow": true,
   "dependencies": [
     "application_credentials",
     "diagnostics"
   ],
-  "documentation": "https://github.com/rbridal/Uhome-HA",
-  "issue_tracker": "https://github.com/rbridal/Uhome-HA/issues",
+  "documentation": "https://github.com/LF2b2w/Uhome-HA",
+  "issue_tracker": "https://github.com/LF2b2w/Uhome-HA/issues",
   "iot_class": "cloud_polling",
   "requirements": [
     "utec_py_LF2b2w==0.4.0"

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,6 +1,6 @@
 """Tests for AsyncPushUpdateHandler._handle_webhook (security boundary)."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -129,6 +129,52 @@ async def test_accepts_cloudhook_list_payload_without_read(webhook_handler, hass
     coord.update_push_data.assert_awaited_once_with(list_payload)
 
 
+async def test_accepts_list_payload_via_read_fallback(webhook_handler, hass):
+    """read()-only path with a top-level list body (no json())."""
+    h, coord = webhook_handler
+    list_body = b'[{"id": "lock-1", "states": []}]'
+    req = _make_request(
+        body=list_body,
+        support_json=False,
+        headers={"Authorization": "Bearer correct-secret"},
+    )
+    resp = await h._handle_webhook(hass, "wh-id", req)
+    assert resp.status == 200
+    coord.update_push_data.assert_awaited_once()
+    args = coord.update_push_data.await_args.args[0]
+    assert isinstance(args, list)
+    assert args[0]["id"] == "lock-1"
+
+
+async def test_rejects_scalar_json_body(webhook_handler, hass):
+    """Top-level scalar JSON must 400 — not be forwarded to the coordinator."""
+    h, coord = webhook_handler
+    req = _make_request(
+        support_read=False,
+        json_data="not-an-object",
+        headers={"Authorization": "Bearer correct-secret"},
+    )
+    resp = await h._handle_webhook(hass, "wh-id", req)
+    assert resp.status == 400
+    coord.update_push_data.assert_not_awaited()
+
+
+async def test_rejects_null_json_body(webhook_handler, hass):
+    """Top-level null JSON must 400."""
+    h, coord = webhook_handler
+    req = _make_request(
+        support_read=False,
+        json_data=None,
+        headers={"Authorization": "Bearer correct-secret"},
+    )
+    # json_data=None makes support_json parse from body default "{}" — force null
+    req.json = AsyncMock(return_value=None)
+    del req.read
+    resp = await h._handle_webhook(hass, "wh-id", req)
+    assert resp.status == 400
+    coord.update_push_data.assert_not_awaited()
+
+
 async def test_rejects_unknown_entry_id(hass, mock_uhome_api):
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="bogus")
     h._push_secret = "s"
@@ -166,3 +212,21 @@ async def test_rejects_when_push_secret_not_initialised(hass, mock_uhome_api):
     resp = await h._handle_webhook(hass, "wh-id", req)
     assert resp.status == 401
     coord.update_push_data.assert_not_awaited()
+
+
+async def test_unregister_deletes_cloudhook_when_used(hass, mock_uhome_api):
+    """Full entry removal must delete the Nabu Casa cloudhook, not only local handler."""
+    h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="entry-1")
+    h._unregister_webhook = True
+    h._used_cloudhook = True
+
+    with patch("custom_components.u_tec.api.webhook.async_unregister") as mock_unreg, patch(
+        "homeassistant.components.cloud.async_delete_cloudhook",
+        new_callable=AsyncMock,
+    ) as mock_delete:
+        await h.unregister_webhook()
+
+    mock_unreg.assert_called_once_with(hass, h.webhook_id)
+    mock_delete.assert_awaited_once_with(hass, h.webhook_id)
+    assert h._used_cloudhook is False
+    assert h._unregister_webhook is None

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -13,7 +13,7 @@ def _make_request(
     *,
     body: bytes = b"{}",
     headers: dict | None = None,
-    json_data: dict | None = None,
+    json_data: dict | list | None = None,
     support_read: bool = True,
     support_json: bool = True,
 ):
@@ -113,6 +113,20 @@ async def test_accepts_cloudhook_style_request_without_read(webhook_handler, has
     resp = await h._handle_webhook(hass, "wh-id", req)
     assert resp.status == 200
     coord.update_push_data.assert_awaited_once()
+
+
+async def test_accepts_cloudhook_list_payload_without_read(webhook_handler, hass):
+    """Cloudhook MockRequest with a top-level list body (issue #30 shape)."""
+    h, coord = webhook_handler
+    list_payload = [{"id": "lock-1", "states": []}]
+    req = _make_request(
+        support_read=False,
+        json_data=list_payload,
+        headers={"Authorization": "Bearer correct-secret"},
+    )
+    resp = await h._handle_webhook(hass, "wh-id", req)
+    assert resp.status == 200
+    coord.update_push_data.assert_awaited_once_with(list_payload)
 
 
 async def test_rejects_unknown_entry_id(hass, mock_uhome_api):

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -162,14 +162,13 @@ async def test_rejects_scalar_json_body(webhook_handler, hass):
 async def test_rejects_null_json_body(webhook_handler, hass):
     """Top-level null JSON must 400."""
     h, coord = webhook_handler
+    # support_read=False already removes read(); force json() to return null.
     req = _make_request(
         support_read=False,
-        json_data=None,
+        json_data={"placeholder": True},
         headers={"Authorization": "Bearer correct-secret"},
     )
-    # json_data=None makes support_json parse from body default "{}" — force null
     req.json = AsyncMock(return_value=None)
-    del req.read
     resp = await h._handle_webhook(hass, "wh-id", req)
     assert resp.status == 400
     coord.update_push_data.assert_not_awaited()
@@ -214,19 +213,35 @@ async def test_rejects_when_push_secret_not_initialised(hass, mock_uhome_api):
     coord.update_push_data.assert_not_awaited()
 
 
+async def test_unregister_always_attempts_cloudhook_delete(hass, mock_uhome_api):
+    """Unregister always calls _delete_cloudhook (idempotent; not gated on flag)."""
+    h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="entry-1")
+    h._unregister_webhook = True
+    h._used_cloudhook = False  # even when flag is False, still attempt delete
+
+    with patch("custom_components.u_tec.api.webhook.async_unregister") as mock_unreg, patch.object(
+        h, "_delete_cloudhook", new_callable=AsyncMock
+    ) as mock_delete:
+        await h.unregister_webhook()
+
+    mock_unreg.assert_called_once_with(hass, h.webhook_id)
+    mock_delete.assert_awaited_once()
+    assert h._used_cloudhook is False
+    assert h._unregister_webhook is None
+
+
 async def test_unregister_deletes_cloudhook_when_used(hass, mock_uhome_api):
     """Full entry removal must delete the Nabu Casa cloudhook, not only local handler."""
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="entry-1")
     h._unregister_webhook = True
     h._used_cloudhook = True
 
-    with patch("custom_components.u_tec.api.webhook.async_unregister") as mock_unreg, patch(
-        "homeassistant.components.cloud.async_delete_cloudhook",
-        new_callable=AsyncMock,
+    with patch("custom_components.u_tec.api.webhook.async_unregister") as mock_unreg, patch.object(
+        h, "_delete_cloudhook", new_callable=AsyncMock
     ) as mock_delete:
         await h.unregister_webhook()
 
     mock_unreg.assert_called_once_with(hass, h.webhook_id)
-    mock_delete.assert_awaited_once_with(hass, h.webhook_id)
+    mock_delete.assert_awaited_once()
     assert h._used_cloudhook is False
     assert h._unregister_webhook is None

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -8,11 +8,45 @@ from custom_components.u_tec.api import AsyncPushUpdateHandler
 from custom_components.u_tec.const import DOMAIN
 
 
-def _make_request(method: str = "POST", *, body: bytes = b"{}", headers: dict | None = None):
+def _make_request(
+    method: str = "POST",
+    *,
+    body: bytes = b"{}",
+    headers: dict | None = None,
+    json_data: dict | None = None,
+    support_read: bool = True,
+    support_json: bool = True,
+):
+    """Build a request mock supporting read() and/or json().
+
+    Cloudhooks use a MockRequest with json() but no read(). Local deliveries
+    use a full aiohttp Request with both.
+    """
     req = MagicMock()
     req.method = method
-    req.read = AsyncMock(return_value=body)
     req.headers = headers or {}
+
+    if support_read:
+        req.read = AsyncMock(return_value=body)
+    else:
+        # Simulate cloud MockRequest — no read attribute at all.
+        del req.read
+
+    if support_json:
+        if json_data is not None:
+            req.json = AsyncMock(return_value=json_data)
+        else:
+            import json as _json
+
+            try:
+                parsed = _json.loads(body)
+            except Exception:  # noqa: BLE001
+                req.json = AsyncMock(side_effect=ValueError("bad json"))
+            else:
+                req.json = AsyncMock(return_value=parsed)
+    else:
+        del req.json
+
     return req
 
 
@@ -35,7 +69,7 @@ async def test_rejects_non_post_method(webhook_handler, hass):
 
 async def test_rejects_invalid_json_body(webhook_handler, hass):
     h, _ = webhook_handler
-    req = _make_request(body=b"not-json")
+    req = _make_request(body=b"not-json", support_json=False)
     resp = await h._handle_webhook(hass, "wh-id", req)
     assert resp.status == 400
 
@@ -61,6 +95,19 @@ async def test_accepts_correct_bearer_token(webhook_handler, hass):
     h, coord = webhook_handler
     req = _make_request(
         body=b'{"payload": {"devices": []}}',
+        headers={"Authorization": "Bearer correct-secret"},
+    )
+    resp = await h._handle_webhook(hass, "wh-id", req)
+    assert resp.status == 200
+    coord.update_push_data.assert_awaited_once()
+
+
+async def test_accepts_cloudhook_style_request_without_read(webhook_handler, hass):
+    """Nabu Casa cloudhooks deliver MockRequest with json() but no read()."""
+    h, coord = webhook_handler
+    req = _make_request(
+        support_read=False,
+        json_data={"payload": {"devices": []}},
         headers={"Authorization": "Bearer correct-secret"},
     )
     resp = await h._handle_webhook(hass, "wh-id", req)

--- a/tests/test_webhook_registration.py
+++ b/tests/test_webhook_registration.py
@@ -9,13 +9,14 @@ from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
 from custom_components.u_tec.api import AsyncPushUpdateHandler
 
+# Cloud is lazy-imported inside _resolve_webhook_url, so patch the real module.
+_CLOUD_ACTIVE = "homeassistant.components.cloud.async_active_subscription"
+_CLOUD_HOOK = "homeassistant.components.cloud.async_get_or_create_cloudhook"
+
 
 def _patch_no_cloud():
     """Disable the cloudhook path so tests exercise network.get_url fallbacks."""
-    return patch(
-        "custom_components.u_tec.api.cloud.async_active_subscription",
-        return_value=False,
-    )
+    return patch(_CLOUD_ACTIVE, return_value=False)
 
 
 async def test_register_succeeds_with_external_url(hass, mock_uhome_api):
@@ -46,11 +47,8 @@ async def test_register_prefers_cloudhook_when_cloud_active(hass, mock_uhome_api
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
     cloudhook_url = "https://hooks.nabu.casa/abc123"
 
-    with patch(
-        "custom_components.u_tec.api.cloud.async_active_subscription",
-        return_value=True,
-    ), patch(
-        "custom_components.u_tec.api.cloud.async_get_or_create_cloudhook",
+    with patch(_CLOUD_ACTIVE, return_value=True), patch(
+        _CLOUD_HOOK,
         new_callable=AsyncMock,
         return_value=cloudhook_url,
     ) as mock_cloudhook, patch(
@@ -77,11 +75,8 @@ async def test_register_falls_back_when_cloudhook_fails(hass, mock_uhome_api):
     """Cloudhook creation error → fall back to network.get_url."""
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
 
-    with patch(
-        "custom_components.u_tec.api.cloud.async_active_subscription",
-        return_value=True,
-    ), patch(
-        "custom_components.u_tec.api.cloud.async_get_or_create_cloudhook",
+    with patch(_CLOUD_ACTIVE, return_value=True), patch(
+        _CLOUD_HOOK,
         new_callable=AsyncMock,
         side_effect=RuntimeError("cloud unavailable"),
     ), patch(

--- a/tests/test_webhook_registration.py
+++ b/tests/test_webhook_registration.py
@@ -9,14 +9,15 @@ from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
 from custom_components.u_tec.api import AsyncPushUpdateHandler
 
-# Cloud is lazy-imported inside _resolve_webhook_url, so patch the real module.
-_CLOUD_ACTIVE = "homeassistant.components.cloud.async_active_subscription"
-_CLOUD_HOOK = "homeassistant.components.cloud.async_get_or_create_cloudhook"
+# Patch the helper so tests never import homeassistant.components.cloud.
+_TRY_CLOUDHOOK = (
+    "custom_components.u_tec.api.AsyncPushUpdateHandler._try_get_cloudhook_url"
+)
 
 
 def _patch_no_cloud():
     """Disable the cloudhook path so tests exercise network.get_url fallbacks."""
-    return patch(_CLOUD_ACTIVE, return_value=False)
+    return patch(_TRY_CLOUDHOOK, new_callable=AsyncMock, return_value=None)
 
 
 async def test_register_succeeds_with_external_url(hass, mock_uhome_api):
@@ -43,14 +44,12 @@ async def test_register_succeeds_with_external_url(hass, mock_uhome_api):
 
 
 async def test_register_prefers_cloudhook_when_cloud_active(hass, mock_uhome_api):
-    """Nabu Casa active → use cloudhook, skip network.get_url."""
+    """Cloudhook available → use it, skip network.get_url."""
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
     cloudhook_url = "https://hooks.nabu.casa/abc123"
 
-    with patch(_CLOUD_ACTIVE, return_value=True), patch(
-        _CLOUD_HOOK,
-        new_callable=AsyncMock,
-        return_value=cloudhook_url,
+    with patch(
+        _TRY_CLOUDHOOK, new_callable=AsyncMock, return_value=cloudhook_url
     ) as mock_cloudhook, patch(
         "custom_components.u_tec.api.network.get_url",
     ) as mock_get_url, patch(
@@ -63,7 +62,7 @@ async def test_register_prefers_cloudhook_when_cloud_active(hass, mock_uhome_api
         result = await h.async_register_webhook(auth_data=MagicMock())
 
     assert result is True
-    mock_cloudhook.assert_awaited_once_with(hass, h.webhook_id)
+    mock_cloudhook.assert_awaited_once()
     mock_get_url.assert_not_called()
     mock_uhome_api.set_push_status.assert_awaited_once()
     assert mock_uhome_api.set_push_status.await_args.args[0] == cloudhook_url
@@ -71,15 +70,11 @@ async def test_register_prefers_cloudhook_when_cloud_active(hass, mock_uhome_api
     assert h.webhook_url == cloudhook_url
 
 
-async def test_register_falls_back_when_cloudhook_fails(hass, mock_uhome_api):
-    """Cloudhook creation error → fall back to network.get_url."""
+async def test_register_falls_back_when_cloudhook_unavailable(hass, mock_uhome_api):
+    """No cloudhook → fall back to network.get_url."""
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
 
-    with patch(_CLOUD_ACTIVE, return_value=True), patch(
-        _CLOUD_HOOK,
-        new_callable=AsyncMock,
-        side_effect=RuntimeError("cloud unavailable"),
-    ), patch(
+    with _patch_no_cloud(), patch(
         "custom_components.u_tec.api.network.get_url",
         return_value="https://ha.example.com",
     ), patch(
@@ -113,7 +108,7 @@ async def test_register_fails_when_no_url_available(hass, mock_uhome_api):
 
 
 async def test_register_falls_back_through_url_strategies(hass, mock_uhome_api):
-    """First strategy fails, second succeeds — cloud fallback path."""
+    """First strategy fails, second succeeds — network fallback path."""
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
 
     call_count = [0]

--- a/tests/test_webhook_registration.py
+++ b/tests/test_webhook_registration.py
@@ -1,7 +1,7 @@
 """Tests for AsyncPushUpdateHandler.async_register_webhook — URL resolution."""
 
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.helpers.network import NoURLAvailableError
 from homeassistant.util import dt as dt_util
@@ -10,10 +10,18 @@ from pytest_homeassistant_custom_component.common import async_fire_time_changed
 from custom_components.u_tec.api import AsyncPushUpdateHandler
 
 
+def _patch_no_cloud():
+    """Disable the cloudhook path so tests exercise network.get_url fallbacks."""
+    return patch(
+        "custom_components.u_tec.api.cloud.async_active_subscription",
+        return_value=False,
+    )
+
+
 async def test_register_succeeds_with_external_url(hass, mock_uhome_api):
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
 
-    with patch(
+    with _patch_no_cloud(), patch(
         "custom_components.u_tec.api.network.get_url",
         return_value="https://ha.example.com",
     ), patch(
@@ -30,12 +38,76 @@ async def test_register_succeeds_with_external_url(hass, mock_uhome_api):
 
     assert result is True
     mock_uhome_api.set_push_status.assert_awaited_once()
+    assert h._used_cloudhook is False
+
+
+async def test_register_prefers_cloudhook_when_cloud_active(hass, mock_uhome_api):
+    """Nabu Casa active → use cloudhook, skip network.get_url."""
+    h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
+    cloudhook_url = "https://hooks.nabu.casa/abc123"
+
+    with patch(
+        "custom_components.u_tec.api.cloud.async_active_subscription",
+        return_value=True,
+    ), patch(
+        "custom_components.u_tec.api.cloud.async_get_or_create_cloudhook",
+        new_callable=AsyncMock,
+        return_value=cloudhook_url,
+    ) as mock_cloudhook, patch(
+        "custom_components.u_tec.api.network.get_url",
+    ) as mock_get_url, patch(
+        "custom_components.u_tec.api.webhook.async_register",
+        return_value=None,
+    ), patch(
+        "custom_components.u_tec.api.async_track_time_interval",
+        return_value=MagicMock(),
+    ):
+        result = await h.async_register_webhook(auth_data=MagicMock())
+
+    assert result is True
+    mock_cloudhook.assert_awaited_once_with(hass, h.webhook_id)
+    mock_get_url.assert_not_called()
+    mock_uhome_api.set_push_status.assert_awaited_once()
+    assert mock_uhome_api.set_push_status.await_args.args[0] == cloudhook_url
+    assert h._used_cloudhook is True
+    assert h.webhook_url == cloudhook_url
+
+
+async def test_register_falls_back_when_cloudhook_fails(hass, mock_uhome_api):
+    """Cloudhook creation error → fall back to network.get_url."""
+    h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
+
+    with patch(
+        "custom_components.u_tec.api.cloud.async_active_subscription",
+        return_value=True,
+    ), patch(
+        "custom_components.u_tec.api.cloud.async_get_or_create_cloudhook",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("cloud unavailable"),
+    ), patch(
+        "custom_components.u_tec.api.network.get_url",
+        return_value="https://ha.example.com",
+    ), patch(
+        "custom_components.u_tec.api.webhook.async_generate_url",
+        return_value="https://ha.example.com/api/webhook/x",
+    ), patch(
+        "custom_components.u_tec.api.webhook.async_register",
+        return_value=None,
+    ), patch(
+        "custom_components.u_tec.api.async_track_time_interval",
+        return_value=MagicMock(),
+    ):
+        result = await h.async_register_webhook(auth_data=MagicMock())
+
+    assert result is True
+    assert h._used_cloudhook is False
+    mock_uhome_api.set_push_status.assert_awaited_once()
 
 
 async def test_register_fails_when_no_url_available(hass, mock_uhome_api):
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
 
-    with patch(
+    with _patch_no_cloud(), patch(
         "custom_components.u_tec.api.network.get_url",
         side_effect=NoURLAvailableError("no external URL configured"),
     ):
@@ -57,7 +129,7 @@ async def test_register_falls_back_through_url_strategies(hass, mock_uhome_api):
             raise NoURLAvailableError("first strategy unavailable")
         return "https://cloud.example.com"
 
-    with patch(
+    with _patch_no_cloud(), patch(
         "custom_components.u_tec.api.network.get_url", side_effect=_get_url,
     ), patch(
         "custom_components.u_tec.api.webhook.async_generate_url",
@@ -81,7 +153,7 @@ async def test_register_fails_when_api_set_push_status_errors(hass, mock_uhome_a
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
     mock_uhome_api.set_push_status.side_effect = ApiError(500, "fail")
 
-    with patch(
+    with _patch_no_cloud(), patch(
         "custom_components.u_tec.api.network.get_url",
         return_value="https://ha.example.com",
     ), patch(
@@ -102,7 +174,7 @@ async def test_register_fails_when_api_set_push_status_errors(hass, mock_uhome_a
 async def test_register_generates_new_secret_each_call(hass, mock_uhome_api):
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
 
-    with patch(
+    with _patch_no_cloud(), patch(
         "custom_components.u_tec.api.network.get_url",
         return_value="https://ha.example.com",
     ), patch(
@@ -155,7 +227,7 @@ async def test_register_twice_does_not_re_register_handler(hass, mock_uhome_api)
     """
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
 
-    with patch(
+    with _patch_no_cloud(), patch(
         "custom_components.u_tec.api.network.get_url",
         return_value="https://ha.example.com",
     ), patch(
@@ -184,7 +256,7 @@ async def test_24h_reregister_timer_does_not_raise(hass, mock_uhome_api):
     """
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
 
-    with patch(
+    with _patch_no_cloud(), patch(
         "custom_components.u_tec.api.network.get_url",
         return_value="https://ha.example.com",
     ), patch(


### PR DESCRIPTION
## Summary

Prefer Nabu Casa **cloudhooks** for push webhook registration when Home Assistant Cloud is active, and fix cloudhook request body parsing.

When Cloud is active, use `cloud.async_get_or_create_cloudhook` instead of relying on `network.get_url(prefer_cloud=True)`. Cloudhooks are the supported inbound path and remain reachable when the remote UI URL changes. Falls back to the existing multi-strategy `network.get_url` path when Cloud is inactive or cloudhook creation fails.

Also fixes a crash on cloudhook delivery: HA Cloud uses a `MockRequest` that exposes `json()` but not `read()`, which previously raised:

`AttributeError: 'MockRequest' object has no attribute 'read'`

## Changes

- Prefer cloudhook URL when Home Assistant Cloud has an active subscription
- Keep existing external/internal URL fallback strategies for non-Cloud setups
- Parse webhook bodies via `json()` with `read()` fallback (aiohttp + cloud MockRequest)
- Lazy-load `homeassistant.components.cloud` so module import stays light
- Unit tests for cloudhook preference, fallback, and MockRequest-style requests

## Testing

- **Live:** push updates received via `hooks.nabu.casa` and applied to lock state
- **Unit:** `pytest tests/` → **242 passed, 1 skipped**

## Notes

Manifest version left as upstream’s so this PR is limited to the functional change. Happy to bump version in a follow-up if preferred.
