### PR TITLE
Tolerate single poll failures; add UI poll interval option

### DIFF
--- a/custom_components/u_tec/__init__.py
+++ b/custom_components/u_tec/__init__.py
@@ -60,6 +60,12 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     hass.data.setdefault(DOMAIN, {})
     if DOMAIN in config:
         hass.data[DOMAIN][_YAML_CONFIG_KEY] = config[DOMAIN]
+        if CONF_SCAN_INTERVAL in config[DOMAIN]:
+            _LOGGER.warning(
+                "configuration.yaml scan_interval for u_tec is deprecated; "
+                "configure the poll interval via Configure → Polling Interval. "
+                "The YAML value is still used until a UI value is saved."
+            )
         _LOGGER.debug(
             "Loaded u_tec config from configuration.yaml: scan_interval=%s, discovery_interval=%s",
             config[DOMAIN].get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
@@ -69,7 +75,12 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 
 
 def _resolve_scan_interval(hass: HomeAssistant, entry: ConfigEntry) -> int:
-    """Prefer entry options, then configuration.yaml, then the built-in default."""
+    """Prefer an explicitly saved UI option, then configuration.yaml, then default.
+
+    scan_interval is only written to entry.options when the user saves the
+    Polling Interval options step — not on initial entry create — so YAML
+    continues to apply until the user opts into the UI setting.
+    """
     if CONF_SCAN_INTERVAL in entry.options:
         return int(entry.options[CONF_SCAN_INTERVAL])
     yaml_config = hass.data.get(DOMAIN, {}).get(_YAML_CONFIG_KEY, {})
@@ -92,7 +103,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     Uhomeapi = UHomeApi(auth_data)
 
-    # Options (UI) override configuration.yaml, which overrides the default.
+    # Explicit UI option > configuration.yaml > built-in default.
     yaml_config = hass.data.get(DOMAIN, {}).get(_YAML_CONFIG_KEY, {})
     scan_interval = _resolve_scan_interval(hass, entry)
     discovery_interval = yaml_config.get(
@@ -193,10 +204,15 @@ async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
             await webhook_handler.unregister_webhook()
         entry_data["push_enabled"] = new_push_enabled
 
-    # Apply poll interval without a full reload.
+    # Apply poll interval without a full reload. Setting update_interval alone
+    # may not reschedule an already-pending timer on all HA versions, so call
+    # _schedule_refresh when available.
     if CONF_SCAN_INTERVAL in entry.options:
         new_interval = int(entry.options[CONF_SCAN_INTERVAL])
         coordinator.update_interval = timedelta(seconds=new_interval)
+        schedule = getattr(coordinator, "_schedule_refresh", None)
+        if callable(schedule):
+            schedule()
         _LOGGER.debug("Updated poll interval to %ds", new_interval)
 
 

--- a/custom_components/u_tec/__init__.py
+++ b/custom_components/u_tec/__init__.py
@@ -23,6 +23,9 @@ from .const import (
     DEFAULT_DISCOVERY_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    MAX_SCAN_INTERVAL,
+    MIN_SCAN_INTERVAL,
+    YAML_CONFIG_KEY,
 )
 from .coordinator import UhomeDataUpdateCoordinator
 
@@ -51,20 +54,19 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-# Key used inside hass.data[DOMAIN] for yaml-sourced config (separate from entry IDs).
-_YAML_CONFIG_KEY = "_yaml_config"
-
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Read configuration.yaml settings and store for use by config entries."""
     hass.data.setdefault(DOMAIN, {})
     if DOMAIN in config:
-        hass.data[DOMAIN][_YAML_CONFIG_KEY] = config[DOMAIN]
+        hass.data[DOMAIN][YAML_CONFIG_KEY] = config[DOMAIN]
         if CONF_SCAN_INTERVAL in config[DOMAIN]:
             _LOGGER.warning(
                 "configuration.yaml scan_interval for u_tec is deprecated; "
                 "configure the poll interval via Configure → Polling Interval. "
-                "The YAML value is still used until a UI value is saved."
+                "YAML applies only until a UI value is saved; after that the UI "
+                "value takes permanent precedence (remove the options key to "
+                "fall back to YAML again)."
             )
         _LOGGER.debug(
             "Loaded u_tec config from configuration.yaml: scan_interval=%s, discovery_interval=%s",
@@ -79,12 +81,15 @@ def _resolve_scan_interval(hass: HomeAssistant, entry: ConfigEntry) -> int:
 
     scan_interval is only written to entry.options when the user saves the
     Polling Interval options step — not on initial entry create — so YAML
-    continues to apply until the user opts into the UI setting.
+    continues to apply until the user opts into the UI setting. Values are
+    clamped to [MIN_SCAN_INTERVAL, MAX_SCAN_INTERVAL].
     """
     if CONF_SCAN_INTERVAL in entry.options:
-        return int(entry.options[CONF_SCAN_INTERVAL])
-    yaml_config = hass.data.get(DOMAIN, {}).get(_YAML_CONFIG_KEY, {})
-    return int(yaml_config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))
+        value = int(entry.options[CONF_SCAN_INTERVAL])
+    else:
+        yaml_config = hass.data.get(DOMAIN, {}).get(YAML_CONFIG_KEY, {})
+        value = int(yaml_config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))
+    return max(MIN_SCAN_INTERVAL, min(MAX_SCAN_INTERVAL, value))
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -104,7 +109,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     Uhomeapi = UHomeApi(auth_data)
 
     # Explicit UI option > configuration.yaml > built-in default.
-    yaml_config = hass.data.get(DOMAIN, {}).get(_YAML_CONFIG_KEY, {})
+    yaml_config = hass.data.get(DOMAIN, {}).get(YAML_CONFIG_KEY, {})
     scan_interval = _resolve_scan_interval(hass, entry)
     discovery_interval = yaml_config.get(
         CONF_DISCOVERY_INTERVAL, DEFAULT_DISCOVERY_INTERVAL
@@ -206,9 +211,12 @@ async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
     # Apply poll interval without a full reload. Setting update_interval alone
     # may not reschedule an already-pending timer on all HA versions, so call
-    # _schedule_refresh when available.
+    # _schedule_refresh when available (private HA API; getattr guards crashes).
     if CONF_SCAN_INTERVAL in entry.options:
-        new_interval = int(entry.options[CONF_SCAN_INTERVAL])
+        new_interval = max(
+            MIN_SCAN_INTERVAL,
+            min(MAX_SCAN_INTERVAL, int(entry.options[CONF_SCAN_INTERVAL])),
+        )
         coordinator.update_interval = timedelta(seconds=new_interval)
         schedule = getattr(coordinator, "_schedule_refresh", None)
         if callable(schedule):

--- a/custom_components/u_tec/__init__.py
+++ b/custom_components/u_tec/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 import logging
 
 import voluptuous as vol
@@ -67,6 +68,14 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     return True
 
 
+def _resolve_scan_interval(hass: HomeAssistant, entry: ConfigEntry) -> int:
+    """Prefer entry options, then configuration.yaml, then the built-in default."""
+    if CONF_SCAN_INTERVAL in entry.options:
+        return int(entry.options[CONF_SCAN_INTERVAL])
+    yaml_config = hass.data.get(DOMAIN, {}).get(_YAML_CONFIG_KEY, {})
+    return int(yaml_config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Uhome from a config entry."""
     implementation = (
@@ -83,10 +92,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     Uhomeapi = UHomeApi(auth_data)
 
-    # Pick up any overrides from configuration.yaml, falling back to defaults.
+    # Options (UI) override configuration.yaml, which overrides the default.
     yaml_config = hass.data.get(DOMAIN, {}).get(_YAML_CONFIG_KEY, {})
-    scan_interval = yaml_config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-    discovery_interval = yaml_config.get(CONF_DISCOVERY_INTERVAL, DEFAULT_DISCOVERY_INTERVAL)
+    scan_interval = _resolve_scan_interval(hass, entry)
+    discovery_interval = yaml_config.get(
+        CONF_DISCOVERY_INTERVAL, DEFAULT_DISCOVERY_INTERVAL
+    )
 
     coordinator = UhomeDataUpdateCoordinator(
         hass,
@@ -160,9 +171,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options update.
 
-    Reconciles webhook registration and push_devices inline based on the new
-    options. Deliberately does NOT call async_reload — token refreshes update
-    entry.data and would otherwise trigger a reload on every refresh.
+    Reconciles webhook registration, push_devices, and poll interval inline
+    based on the new options. Deliberately does NOT call async_reload — token
+    refreshes update entry.data and would otherwise trigger a reload on every
+    refresh.
     """
     entry_data = hass.data[DOMAIN][entry.entry_id]
     webhook_handler = entry_data["webhook_handler"]
@@ -180,6 +192,12 @@ async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
         else:
             await webhook_handler.unregister_webhook()
         entry_data["push_enabled"] = new_push_enabled
+
+    # Apply poll interval without a full reload.
+    if CONF_SCAN_INTERVAL in entry.options:
+        new_interval = int(entry.options[CONF_SCAN_INTERVAL])
+        coordinator.update_interval = timedelta(seconds=new_interval)
+        _LOGGER.debug("Updated poll interval to %ds", new_interval)
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/custom_components/u_tec/api.py
+++ b/custom_components/u_tec/api.py
@@ -206,6 +206,34 @@ class AsyncPushUpdateHandler:
             self._unregister_webhook = None
             _LOGGER.debug("Unregistered webhook %s", self.webhook_id)
 
+    async def _parse_request_body(self, request) -> dict:
+        """Parse JSON body from either aiohttp Request or cloud MockRequest.
+
+        Nabu Casa cloudhooks deliver a MockRequest that exposes ``json()`` but
+        not ``read()``. Local webhook deliveries use a full aiohttp Request
+        with both. Prefer ``json()`` when available; fall back to ``read()``.
+        """
+        # Prefer json() — works for cloud MockRequest and aiohttp Request.
+        json_method = getattr(request, "json", None)
+        if callable(json_method):
+            try:
+                data = await json_method()
+                if isinstance(data, dict):
+                    return data
+            except Exception:  # noqa: BLE001
+                # Fall through to read() path.
+                pass
+
+        read_method = getattr(request, "read", None)
+        if callable(read_method):
+            raw_body = await read_method()
+            if isinstance(raw_body, bytes):
+                return json.loads(raw_body)
+            if isinstance(raw_body, str):
+                return json.loads(raw_body)
+
+        raise ValueError("Request body is not valid JSON")
+
     async def _handle_webhook(
         self, hass: HomeAssistant, webhook_id, request
     ) -> web.Response | None:
@@ -215,19 +243,18 @@ class AsyncPushUpdateHandler:
                 _LOGGER.error("Unsupported method: %s", request.method)
                 return web.Response(status=405)
 
-            raw_body = await request.read()
-            _LOGGER.debug(
-                "Webhook hit received: method=%s headers=%s body=%s",
-                request.method,
-                dict(request.headers),
-                raw_body.decode("utf-8", errors="replace"),
-            )
-
             try:
-                data = json.loads(raw_body)
+                data = await self._parse_request_body(request)
             except Exception as json_err:  # noqa: BLE001
                 _LOGGER.error("Failed to parse webhook JSON: %s", json_err)
                 return web.Response(status=400)
+
+            _LOGGER.debug(
+                "Webhook hit received: method=%s headers=%s data=%s",
+                request.method,
+                dict(getattr(request, "headers", {}) or {}),
+                data,
+            )
 
             # Validate the push secret via the Authorization header.
             # U-Tec sends it as "Bearer <access_token>" in the HTTP header.
@@ -238,7 +265,9 @@ class AsyncPushUpdateHandler:
                     "Webhook received before push secret was initialised -- rejecting"
                 )
                 return web.Response(status=401)
-            auth_header = request.headers.get("Authorization", "")
+            auth_header = (getattr(request, "headers", {}) or {}).get(
+                "Authorization", ""
+            )
             incoming_token = auth_header.removeprefix("Bearer ").strip()
             if not incoming_token:
                 _LOGGER.warning(

--- a/custom_components/u_tec/api.py
+++ b/custom_components/u_tec/api.py
@@ -61,33 +61,44 @@ class AsyncPushUpdateHandler:
         """Generate a fresh random secret token for push validation."""
         return secrets.token_urlsafe(32)
 
+    async def _try_get_cloudhook_url(self) -> str | None:
+        """Return a Nabu Casa cloudhook URL if Cloud is active, else None.
+
+        Cloud is imported lazily so loading this module does not pull in the
+        full Cloud → Alexa → camera dependency chain. Unit tests patch this
+        method instead of importing homeassistant.components.cloud.
+        """
+        from homeassistant.components import cloud
+
+        if not cloud.async_active_subscription(self.hass):
+            return None
+
+        try:
+            webhook_url = await cloud.async_get_or_create_cloudhook(
+                self.hass, self.webhook_id
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning(
+                "Cloudhook creation failed, falling back to external URL: %s",
+                err,
+            )
+            return None
+
+        if webhook_url:
+            _LOGGER.debug("Using Nabu Casa cloudhook: %s", webhook_url)
+        return webhook_url or None
+
     async def _resolve_webhook_url(self) -> str | None:
         """Resolve an externally-reachable webhook URL.
 
         Prefer a Nabu Casa cloudhook when Home Assistant Cloud is active.
         Otherwise fall back through network.get_url strategies.
-
-        Cloud is imported lazily so loading this module does not pull in the
-        full Cloud → Alexa → camera dependency chain (needed for unit tests
-        and lighter HA startup).
         """
         # 1. Prefer a real cloudhook when Nabu Casa is active.
-        from homeassistant.components import cloud
-
-        if cloud.async_active_subscription(self.hass):
-            try:
-                webhook_url = await cloud.async_get_or_create_cloudhook(
-                    self.hass, self.webhook_id
-                )
-                if webhook_url:
-                    self._used_cloudhook = True
-                    _LOGGER.debug("Using Nabu Casa cloudhook: %s", webhook_url)
-                    return webhook_url
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.warning(
-                    "Cloudhook creation failed, falling back to external URL: %s",
-                    err,
-                )
+        cloudhook_url = await self._try_get_cloudhook_url()
+        if cloudhook_url:
+            self._used_cloudhook = True
+            return cloudhook_url
 
         self._used_cloudhook = False
 

--- a/custom_components/u_tec/api.py
+++ b/custom_components/u_tec/api.py
@@ -88,6 +88,27 @@ class AsyncPushUpdateHandler:
             _LOGGER.debug("Using Nabu Casa cloudhook: %s", webhook_url)
         return webhook_url or None
 
+    async def _delete_cloudhook(self) -> None:
+        """Best-effort delete of any Nabu Casa cloudhook for this webhook_id.
+
+        Always attempted on unregister (idempotent) so a cloudhook created in a
+        previous process lifetime, or after fallback-then-Cloud-reconnect, is
+        still cleaned up. Lazy-imports cloud to avoid the Alexa/turbojpeg import
+        chain — unit tests patch this method as a seam.
+        """
+        try:
+            from homeassistant.components import cloud
+
+            await cloud.async_delete_cloudhook(self.hass, self.webhook_id)
+            _LOGGER.debug("Deleted cloudhook %s", self.webhook_id)
+        except Exception as err:  # noqa: BLE001
+            # Orphaned hooks on hooks.nabu.casa are otherwise invisible.
+            _LOGGER.warning(
+                "Could not delete cloudhook %s (may already be gone): %s",
+                self.webhook_id,
+                err,
+            )
+
     async def _resolve_webhook_url(self) -> str | None:
         """Resolve an externally-reachable webhook URL.
 
@@ -214,7 +235,15 @@ class AsyncPushUpdateHandler:
         )
 
     async def unregister_webhook(self) -> None:
-        """Unregister the webhook and cancel the re-registration scheduler."""
+        """Unregister the webhook and cancel the re-registration scheduler.
+
+        Always attempts cloudhook deletion (idempotent). HA's
+        ``webhook.async_unregister`` only removes the local handler; without
+        ``cloud.async_delete_cloudhook`` an orphaned hook can remain on
+        hooks.nabu.casa after full config-entry removal. Deletion is not gated
+        on ``_used_cloudhook`` so hooks from a prior process lifetime (or after
+        fallback→Cloud reconnect) are still cleaned up.
+        """
         if self._cancel_reregister:
             self._cancel_reregister()
             self._cancel_reregister = None
@@ -222,6 +251,9 @@ class AsyncPushUpdateHandler:
             webhook.async_unregister(self.hass, self.webhook_id)
             self._unregister_webhook = None
             _LOGGER.debug("Unregistered webhook %s", self.webhook_id)
+
+        await self._delete_cloudhook()
+        self._used_cloudhook = False
 
     async def _parse_request_body(self, request) -> dict | list:
         """Parse JSON body from either aiohttp Request or cloud MockRequest.

--- a/custom_components/u_tec/api.py
+++ b/custom_components/u_tec/api.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 
 from aiohttp import ClientSession, web
 
-from homeassistant.components import webhook
+from homeassistant.components import cloud, webhook
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_entry_oauth2_flow, network
 from homeassistant.helpers.event import async_track_time_interval
@@ -55,16 +55,37 @@ class AsyncPushUpdateHandler:
         self._push_secret: str | None = None
         self.api = api
         self._auth_data = None
+        self._used_cloudhook = False
 
     def _generate_secret(self) -> str:
         """Generate a fresh random secret token for push validation."""
         return secrets.token_urlsafe(32)
 
-    async def async_register_webhook(self, auth_data) -> bool:
-        """Register webhook with Home Assistant and the Uhome API."""
-        self._auth_data = auth_data
+    async def _resolve_webhook_url(self) -> str | None:
+        """Resolve an externally-reachable webhook URL.
 
-        # Try multiple URL resolution strategies
+        Prefer a Nabu Casa cloudhook when Home Assistant Cloud is active.
+        Otherwise fall back through network.get_url strategies.
+        """
+        # 1. Prefer a real cloudhook when Nabu Casa is active.
+        if cloud.async_active_subscription(self.hass):
+            try:
+                webhook_url = await cloud.async_get_or_create_cloudhook(
+                    self.hass, self.webhook_id
+                )
+                if webhook_url:
+                    self._used_cloudhook = True
+                    _LOGGER.debug("Using Nabu Casa cloudhook: %s", webhook_url)
+                    return webhook_url
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.warning(
+                    "Cloudhook creation failed, falling back to external URL: %s",
+                    err,
+                )
+
+        self._used_cloudhook = False
+
+        # 2. Fall back through network.get_url strategies.
         external_url = None
         for allow_internal, allow_ip, prefer_cloud in [
             (False, False, False),
@@ -81,13 +102,26 @@ class AsyncPushUpdateHandler:
                 if external_url:
                     _LOGGER.debug(
                         "Resolved webhook base URL: %s (internal=%s, cloud=%s)",
-                        external_url, allow_internal, prefer_cloud,
+                        external_url,
+                        allow_internal,
+                        prefer_cloud,
                     )
                     break
             except NoURLAvailableError:
                 continue
 
         if not external_url:
+            return None
+
+        return webhook.async_generate_url(self.hass, self.webhook_id)
+
+    async def async_register_webhook(self, auth_data) -> bool:
+        """Register webhook with Home Assistant and the Uhome API."""
+        self._auth_data = auth_data
+
+        webhook_url = await self._resolve_webhook_url()
+
+        if not webhook_url:
             _LOGGER.error(
                 "No external URL available for push notifications. "
                 "Configure an external URL in Settings -> System -> Network, "
@@ -95,11 +129,17 @@ class AsyncPushUpdateHandler:
             )
             return False
 
-        webhook_url = webhook.async_generate_url(self.hass, self.webhook_id)
-
-        if any(local in webhook_url for local in (
-            "192.168.", "10.", "172.", "homeassistant.local", "localhost", "127.0."
-        )):
+        if not self._used_cloudhook and any(
+            local in webhook_url
+            for local in (
+                "192.168.",
+                "10.",
+                "172.",
+                "homeassistant.local",
+                "localhost",
+                "127.0.",
+            )
+        ):
             _LOGGER.warning(
                 "Webhook URL %s appears to be a local address. "
                 "U-Tec's servers cannot reach it -- push state updates will not work. "
@@ -225,6 +265,8 @@ class AsyncPushUpdateHandler:
             return web.json_response({"success": False, "error": str(err)}, status=400)
         except Exception as err:  # noqa: BLE001
             _LOGGER.exception("Unexpected error processing webhook: %s", err)
-            return web.json_response({"success": False, "error": "Internal error"}, status=500)
+            return web.json_response(
+                {"success": False, "error": "Internal error"}, status=500
+            )
         else:
             return web.json_response({"success": True})

--- a/custom_components/u_tec/api.py
+++ b/custom_components/u_tec/api.py
@@ -223,19 +223,22 @@ class AsyncPushUpdateHandler:
             self._unregister_webhook = None
             _LOGGER.debug("Unregistered webhook %s", self.webhook_id)
 
-    async def _parse_request_body(self, request) -> dict:
+    async def _parse_request_body(self, request) -> dict | list:
         """Parse JSON body from either aiohttp Request or cloud MockRequest.
 
         Nabu Casa cloudhooks deliver a MockRequest that exposes ``json()`` but
         not ``read()``. Local webhook deliveries use a full aiohttp Request
         with both. Prefer ``json()`` when available; fall back to ``read()``.
+
+        Accept both object and array top-level JSON — the coordinator already
+        normalises list-shaped U-Tec push payloads (issue #30).
         """
         # Prefer json() — works for cloud MockRequest and aiohttp Request.
         json_method = getattr(request, "json", None)
         if callable(json_method):
             try:
                 data = await json_method()
-                if isinstance(data, dict):
+                if isinstance(data, (dict, list)):
                     return data
             except Exception:  # noqa: BLE001
                 # Fall through to read() path.
@@ -245,9 +248,13 @@ class AsyncPushUpdateHandler:
         if callable(read_method):
             raw_body = await read_method()
             if isinstance(raw_body, bytes):
-                return json.loads(raw_body)
-            if isinstance(raw_body, str):
-                return json.loads(raw_body)
+                data = json.loads(raw_body)
+            elif isinstance(raw_body, str):
+                data = json.loads(raw_body)
+            else:
+                raise ValueError("Request body is not valid JSON")
+            if isinstance(data, (dict, list)):
+                return data
 
         raise ValueError("Request body is not valid JSON")
 

--- a/custom_components/u_tec/api.py
+++ b/custom_components/u_tec/api.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 
 from aiohttp import ClientSession, web
 
-from homeassistant.components import cloud, webhook
+from homeassistant.components import webhook
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_entry_oauth2_flow, network
 from homeassistant.helpers.event import async_track_time_interval
@@ -66,8 +66,14 @@ class AsyncPushUpdateHandler:
 
         Prefer a Nabu Casa cloudhook when Home Assistant Cloud is active.
         Otherwise fall back through network.get_url strategies.
+
+        Cloud is imported lazily so loading this module does not pull in the
+        full Cloud → Alexa → camera dependency chain (needed for unit tests
+        and lighter HA startup).
         """
         # 1. Prefer a real cloudhook when Nabu Casa is active.
+        from homeassistant.components import cloud
+
         if cloud.async_active_subscription(self.hass):
             try:
                 webhook_url = await cloud.async_get_or_create_cloudhook(

--- a/custom_components/u_tec/binary_sensor.py
+++ b/custom_components/u_tec/binary_sensor.py
@@ -55,8 +55,11 @@ class UhomeDoorSensor(CoordinatorEntity, BinarySensorEntity):
 
     @property
     def available(self) -> bool:
-        """Return True if entity is available."""
-        return self.coordinator.last_update_success and self._device.available
+        """Return True if entity is available.
+
+        Unavailable only when the device is offline or two consecutive polls failed.
+        """
+        return self.coordinator.poll_healthy_enough and self._device.available
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/u_tec/config_flow.py
+++ b/custom_components/u_tec/config_flow.py
@@ -65,6 +65,9 @@ OPTIMISTIC_MODES = [OPTIMISTIC_MODE_ALL, OPTIMISTIC_MODE_NONE, OPTIMISTIC_MODE_C
 _MIN_SCAN_INTERVAL = 10
 _MAX_SCAN_INTERVAL = 3600
 
+# Mirrors __init__._YAML_CONFIG_KEY (avoid importing __init__ from here).
+_YAML_CONFIG_KEY = "_yaml_config"
+
 
 def _current_mode(value: bool | list[str] | None) -> str:
     """Infer the mode selector default from a stored option value."""
@@ -218,11 +221,13 @@ class UhomeOAuth2FlowHandler(
                 options=dict(entry.options),
             )
 
+        # Do not store scan_interval here — only persist it when the user
+        # explicitly saves Configure → Polling Interval, so configuration.yaml
+        # continues to apply until then.
         options = {
             CONF_PUSH_ENABLED: True,
             CONF_PUSH_DEVICES: [],  # Empty list means all devices
             CONF_HA_DEVICES: [],
-            CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
         }
         # Static title — flow_impl.name is "Configuration.yaml" for the in-memory
         # LocalOAuth2Implementation built in async_step_replace_credentials, which
@@ -334,6 +339,15 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         self.options = dict(config_entry.options)
         self._pending_pickers: list[str] = []
 
+    def _default_scan_interval(self) -> int:
+        """UI default: saved option, else YAML, else built-in default."""
+        if CONF_SCAN_INTERVAL in self.options:
+            current = int(self.options[CONF_SCAN_INTERVAL])
+        else:
+            yaml_config = self.hass.data.get(DOMAIN, {}).get(_YAML_CONFIG_KEY, {})
+            current = int(yaml_config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))
+        return max(_MIN_SCAN_INTERVAL, min(_MAX_SCAN_INTERVAL, current))
+
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -355,16 +369,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         """Configure how often device state is polled from the U-Tec API.
 
         With working cloudhooks, a longer interval is usually fine; the default
-        remains 10s for installs that rely on polling alone.
+        remains 10s for installs that rely on polling alone. The form prefill
+        uses any saved UI value, otherwise configuration.yaml, otherwise 10s.
         """
         if user_input is not None:
+            # Only now is scan_interval written to options (explicit user choice).
             self.options[CONF_SCAN_INTERVAL] = int(user_input[CONF_SCAN_INTERVAL])
             return self.async_create_entry(title="", data=self.options)
-
-        current = int(
-            self.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-        )
-        current = max(_MIN_SCAN_INTERVAL, min(_MAX_SCAN_INTERVAL, current))
 
         return self.async_show_form(
             step_id="polling_interval",
@@ -372,7 +383,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 {
                     vol.Required(
                         CONF_SCAN_INTERVAL,
-                        default=current,
+                        default=self._default_scan_interval(),
                     ): NumberSelector(
                         NumberSelectorConfig(
                             min=_MIN_SCAN_INTERVAL,

--- a/custom_components/u_tec/config_flow.py
+++ b/custom_components/u_tec/config_flow.py
@@ -26,6 +26,9 @@ from homeassistant.helpers import config_entry_oauth2_flow
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.selector import (
     BooleanSelector,
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
@@ -43,7 +46,9 @@ from .const import (
     CONF_OPTIMISTIC_SWITCHES,
     CONF_PUSH_DEVICES,
     CONF_PUSH_ENABLED,
+    CONF_SCAN_INTERVAL,
     DEFAULT_API_SCOPE,
+    DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     OAUTH2_AUTHORIZE,
     OAUTH2_TOKEN,
@@ -55,6 +60,10 @@ OPTIMISTIC_MODE_ALL = "all"
 OPTIMISTIC_MODE_NONE = "none"
 OPTIMISTIC_MODE_CUSTOM = "custom"
 OPTIMISTIC_MODES = [OPTIMISTIC_MODE_ALL, OPTIMISTIC_MODE_NONE, OPTIMISTIC_MODE_CUSTOM]
+
+# Bounds for the UI-configurable poll interval (seconds).
+_MIN_SCAN_INTERVAL = 10
+_MAX_SCAN_INTERVAL = 3600
 
 
 def _current_mode(value: bool | list[str] | None) -> str:
@@ -213,6 +222,7 @@ class UhomeOAuth2FlowHandler(
             CONF_PUSH_ENABLED: True,
             CONF_PUSH_DEVICES: [],  # Empty list means all devices
             CONF_HA_DEVICES: [],
+            CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
         }
         # Static title — flow_impl.name is "Configuration.yaml" for the in-memory
         # LocalOAuth2Implementation built in async_step_replace_credentials, which
@@ -312,6 +322,7 @@ class UhomeOAuth2FlowHandler(
         """Get the options flow for this handler."""
         return OptionsFlowHandler(config_entry)
 
+
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options flow with proper device discovery."""
 
@@ -333,7 +344,46 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 "update_push": "Update Push Status",
                 "get_devices": "Select Active Devices",
                 "optimistic_updates": "Configure Optimistic Updates",
+                "polling_interval": "Polling Interval",
             },
+        )
+
+    async def async_step_polling_interval(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Configure how often device state is polled from the U-Tec API.
+
+        With working cloudhooks, a longer interval is usually fine; the default
+        remains 10s for installs that rely on polling alone.
+        """
+        if user_input is not None:
+            self.options[CONF_SCAN_INTERVAL] = int(user_input[CONF_SCAN_INTERVAL])
+            return self.async_create_entry(title="", data=self.options)
+
+        current = int(
+            self.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        )
+        current = max(_MIN_SCAN_INTERVAL, min(_MAX_SCAN_INTERVAL, current))
+
+        return self.async_show_form(
+            step_id="polling_interval",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_SCAN_INTERVAL,
+                        default=current,
+                    ): NumberSelector(
+                        NumberSelectorConfig(
+                            min=_MIN_SCAN_INTERVAL,
+                            max=_MAX_SCAN_INTERVAL,
+                            step=5,
+                            unit_of_measurement="seconds",
+                            mode=NumberSelectorMode.BOX,
+                        )
+                    ),
+                }
+            ),
         )
 
     async def async_step_update_push(
@@ -574,6 +624,3 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 }
             ),
         )
-
-
-

--- a/custom_components/u_tec/config_flow.py
+++ b/custom_components/u_tec/config_flow.py
@@ -50,8 +50,11 @@ from .const import (
     DEFAULT_API_SCOPE,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    MAX_SCAN_INTERVAL,
+    MIN_SCAN_INTERVAL,
     OAUTH2_AUTHORIZE,
     OAUTH2_TOKEN,
+    YAML_CONFIG_KEY,
 )
 from .oauth import UtecLocalOAuth2Implementation
 
@@ -60,13 +63,6 @@ OPTIMISTIC_MODE_ALL = "all"
 OPTIMISTIC_MODE_NONE = "none"
 OPTIMISTIC_MODE_CUSTOM = "custom"
 OPTIMISTIC_MODES = [OPTIMISTIC_MODE_ALL, OPTIMISTIC_MODE_NONE, OPTIMISTIC_MODE_CUSTOM]
-
-# Bounds for the UI-configurable poll interval (seconds).
-_MIN_SCAN_INTERVAL = 10
-_MAX_SCAN_INTERVAL = 3600
-
-# Mirrors __init__._YAML_CONFIG_KEY (avoid importing __init__ from here).
-_YAML_CONFIG_KEY = "_yaml_config"
 
 
 def _current_mode(value: bool | list[str] | None) -> str:
@@ -129,19 +125,7 @@ class UhomeOAuth2FlowHandler(
     async def async_step_replace_credentials(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Render the credential form and start OAuth with an in-memory implementation.
-
-        Used by initial setup (via async_step_user), issue #50 recovery (stale creds
-        in HA's app-creds store from a prior failed attempt), and reconfigure of a
-        working entry (via async_step_reconfigure).
-
-        The application_credentials store is NOT mutated here. We build an in-memory
-        LocalOAuth2Implementation with the entered creds, set self.flow_impl directly,
-        and jump to async_step_auth — bypassing async_step_pick_implementation. The
-        actual store update happens in async_oauth_create_entry, on the OAuth-success
-        path only. Consequence: if OAuth fails, any existing credential is untouched
-        and a working config entry continues to refresh against valid creds.
-        """
+        """Render the credential form and start OAuth with an in-memory implementation."""
         if user_input is not None:
             client_id = (user_input.get("client_id") or "").strip()
             client_secret = (user_input.get("client_secret") or "").strip()
@@ -153,9 +137,6 @@ class UhomeOAuth2FlowHandler(
                 )
 
             self._pending_credential = ClientCredential(client_id, client_secret)
-            # Unwrapping implementation: U-Tec's /token returns the OAuth fields
-            # nested under {"code","data"}, which HA's stock implementation can't
-            # parse. See oauth.py.
             self.flow_impl = UtecLocalOAuth2Implementation(
                 self.hass,
                 DOMAIN,
@@ -193,13 +174,7 @@ class UhomeOAuth2FlowHandler(
     async def async_oauth_create_entry(
         self, data: dict
     ) -> ConfigFlowResult:
-        """Create or update the config entry depending on the flow source.
-
-        If credentials were entered via async_step_replace_credentials and OAuth
-        succeeded, commit them to the application_credentials store now and rewrite
-        the entry's auth_implementation reference to the standard "u_tec" auth_domain
-        (which is what async_get_implementations resolves against).
-        """
+        """Create or update the config entry depending on the flow source."""
         if self._pending_credential is not None:
             await self._commit_pending_credential()
             self._pending_credential = None
@@ -221,40 +196,18 @@ class UhomeOAuth2FlowHandler(
                 options=dict(entry.options),
             )
 
-        # Do not store scan_interval here — only persist it when the user
-        # explicitly saves Configure → Polling Interval, so configuration.yaml
-        # continues to apply until then.
         options = {
             CONF_PUSH_ENABLED: True,
-            CONF_PUSH_DEVICES: [],  # Empty list means all devices
+            CONF_PUSH_DEVICES: [],
             CONF_HA_DEVICES: [],
         }
-        # Static title — flow_impl.name is "Configuration.yaml" for the in-memory
-        # LocalOAuth2Implementation built in async_step_replace_credentials, which
-        # would surface as the entry title in the HA UI. Use the integration name.
         return self.async_create_entry(
             title="U-Tec", data=data, options=options
         )
 
     async def _commit_pending_credential(self) -> None:
-        """Persist the deferred credential to the application_credentials store.
-
-        Called from async_oauth_create_entry on the OAuth-success path. For items
-        whose client_id matches the new one, delete BEFORE import — otherwise
-        async_import_item is a no-op on duplicate suggested_id and the secret
-        wouldn't rotate. Delete failures in that pre-import phase are therefore
-        re-raised so the flow aborts instead of reporting a phantom success. For
-        items with a different client_id, import first then delete: HA's
-        async_delete_item refuses to delete a credential currently
-        referenced by an entry's auth_implementation, but the new cred has the
-        canonical auth_domain ("u_tec") so importing it first means the entry
-        can resolve a valid implementation regardless of whether the legacy
-        delete succeeds. (Legacy entries with auth_implementation pointing at
-        a credential item_id are normalised to the canonical auth_domain by
-        async_migrate_entry at integration setup, so by the time this runs the
-        delete should not be blocked.)
-        """
-        assert self._pending_credential is not None  # guarded by caller
+        """Persist the deferred credential to the application_credentials store."""
+        assert self._pending_credential is not None
         new_client_id = self._pending_credential.client_id
 
         storage = self.hass.data.get(APP_CREDS_DATA)
@@ -270,9 +223,6 @@ class UhomeOAuth2FlowHandler(
                     other_ids.append(item[APP_CREDS_ID])
 
         for item_id in matching_ids:
-            # Delete failure here cannot be swallowed: async_import_client_credential
-            # is a no-op on duplicate suggested_id, so a leftover record means the
-            # secret silently doesn't rotate while OAuth still reports success.
             try:
                 await storage.async_delete_item(item_id)
             except Exception as err:  # noqa: BLE001
@@ -304,13 +254,7 @@ class UhomeOAuth2FlowHandler(
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
-        """Re-authenticate an existing entry.
-
-        Dispatch directly to the credentials form — no confirmation step.
-        The framework hands us the entry's data dict but we don't need it:
-        the form prefills client_id from the application_credentials store,
-        and OAuth-success updates the entry in async_oauth_create_entry.
-        """
+        """Re-authenticate an existing entry."""
         return await self.async_step_replace_credentials()
 
     async def async_step_reconfigure(
@@ -344,9 +288,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if CONF_SCAN_INTERVAL in self.options:
             current = int(self.options[CONF_SCAN_INTERVAL])
         else:
-            yaml_config = self.hass.data.get(DOMAIN, {}).get(_YAML_CONFIG_KEY, {})
+            yaml_config = self.hass.data.get(DOMAIN, {}).get(YAML_CONFIG_KEY, {})
             current = int(yaml_config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))
-        return max(_MIN_SCAN_INTERVAL, min(_MAX_SCAN_INTERVAL, current))
+        return max(MIN_SCAN_INTERVAL, min(MAX_SCAN_INTERVAL, current))
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -366,15 +310,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         self,
         user_input: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
-        """Configure how often device state is polled from the U-Tec API.
-
-        With working cloudhooks, a longer interval is usually fine; the default
-        remains 10s for installs that rely on polling alone. The form prefill
-        uses any saved UI value, otherwise configuration.yaml, otherwise 10s.
-        """
+        """Configure how often device state is polled from the U-Tec API."""
         if user_input is not None:
-            # Only now is scan_interval written to options (explicit user choice).
-            self.options[CONF_SCAN_INTERVAL] = int(user_input[CONF_SCAN_INTERVAL])
+            self.options[CONF_SCAN_INTERVAL] = vol.All(
+                vol.Coerce(int),
+                vol.Range(min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL),
+            )(user_input[CONF_SCAN_INTERVAL])
             return self.async_create_entry(title="", data=self.options)
 
         return self.async_show_form(
@@ -386,8 +327,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         default=self._default_scan_interval(),
                     ): NumberSelector(
                         NumberSelectorConfig(
-                            min=_MIN_SCAN_INTERVAL,
-                            max=_MAX_SCAN_INTERVAL,
+                            min=MIN_SCAN_INTERVAL,
+                            max=MAX_SCAN_INTERVAL,
                             step=5,
                             unit_of_measurement="seconds",
                             mode=NumberSelectorMode.BOX,
@@ -438,7 +379,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             device_id: device.name for device_id, device in coordinator.devices.items()
         }
 
-        # If no devices are selected, default to all devices
         selected_devices = self.options.get(CONF_PUSH_DEVICES, [])
         if not selected_devices:
             selected_devices = list(self.devices.keys())
@@ -538,7 +478,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         }
 
         if not devices:
-            # No devices of this type to pick from — skip to next picker.
             self.options[conf_key] = []
             self._pending_pickers.pop(0)
             return await self._advance_optimistic_picker()
@@ -615,7 +554,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if not self.devices:
             _LOGGER.error("No devices found")
             return self.async_abort(reason="no devices found")
-        # Get the current selection from the config entry options
         current_selection = self.config_entry.options.get("devices", [])
 
         if user_input is not None:
@@ -623,7 +561,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 title="", data={"devices": user_input["selected_devices"]}
             )
 
-        # Show the device selection form
         return self.async_show_form(
             step_id="device_selection",
             data_schema=vol.Schema(

--- a/custom_components/u_tec/const.py
+++ b/custom_components/u_tec/const.py
@@ -22,6 +22,11 @@ DOMAIN = "u_tec"
 # https://github.com/LF2b2w/Uhome-HA/issues/58
 OPTIMISTIC_TIMEOUT = timedelta(seconds=30)
 
+# How many consecutive coordinator poll failures are allowed before entities
+# report unavailable. One failure is treated as a transient blip; two in a
+# row (or a device that reports offline) marks entities unavailable.
+MAX_CONSECUTIVE_UPDATE_FAILURES = 2
+
 CONF_SCAN_INTERVAL = "scan_interval"
 CONF_DISCOVERY_INTERVAL = "discovery_interval"
 

--- a/custom_components/u_tec/const.py
+++ b/custom_components/u_tec/const.py
@@ -25,6 +25,7 @@ OPTIMISTIC_TIMEOUT = timedelta(seconds=30)
 # How many consecutive coordinator poll failures are allowed before entities
 # report unavailable. One failure is treated as a transient blip; two in a
 # row (or a device that reports offline) marks entities unavailable.
+# Auth failures immediately set the counter to this threshold.
 MAX_CONSECUTIVE_UPDATE_FAILURES = 2
 
 CONF_SCAN_INTERVAL = "scan_interval"
@@ -32,6 +33,11 @@ CONF_DISCOVERY_INTERVAL = "discovery_interval"
 
 DEFAULT_SCAN_INTERVAL = 10  # seconds
 DEFAULT_DISCOVERY_INTERVAL = 300  # seconds (5 minutes)
+MIN_SCAN_INTERVAL = 10
+MAX_SCAN_INTERVAL = 3600
+
+# Key used inside hass.data[DOMAIN] for yaml-sourced config (separate from entry IDs).
+YAML_CONFIG_KEY = "_yaml_config"
 
 OAUTH2_AUTHORIZE = "https://oauth.u-tec.com/authorize"
 OAUTH2_TOKEN = "https://oauth.u-tec.com/token"

--- a/custom_components/u_tec/coordinator.py
+++ b/custom_components/u_tec/coordinator.py
@@ -212,7 +212,10 @@ class UhomeDataUpdateCoordinator(DataUpdateCoordinator):
                 device_id: device.get_state_data()
                 for device_id, device in self.devices.items()
             }
-        except (AuthenticationError, ConfigEntryAuthFailed):
+        except AuthenticationError as err:
+            self.consecutive_update_failures += 1
+            raise ConfigEntryAuthFailed(f"Credentials expired: {err}") from err
+        except ConfigEntryAuthFailed:
             self.consecutive_update_failures += 1
             raise
         except ApiError as err:

--- a/custom_components/u_tec/coordinator.py
+++ b/custom_components/u_tec/coordinator.py
@@ -83,7 +83,8 @@ class UhomeDataUpdateCoordinator(DataUpdateCoordinator):
         self._cancel_discovery: callable | None = None
         # Consecutive failed polls. Entities stay available through a single
         # transient failure; two in a row (or a device offline flag) marks them
-        # unavailable. Auth failures still raise ConfigEntryAuthFailed.
+        # unavailable. Auth failures set the counter to the threshold immediately
+        # because HA stops rescheduling after ConfigEntryAuthFailed.
         self.consecutive_update_failures = 0
         _LOGGER.info(
             "Uhome data coordinator initialized (poll=%ds, discovery=%ds)",
@@ -213,10 +214,12 @@ class UhomeDataUpdateCoordinator(DataUpdateCoordinator):
                 for device_id, device in self.devices.items()
             }
         except AuthenticationError as err:
-            self.consecutive_update_failures += 1
+            # HA stops rescheduling after ConfigEntryAuthFailed, so a single
+            # increment would leave entities "available" with stale state.
+            self.consecutive_update_failures = MAX_CONSECUTIVE_UPDATE_FAILURES
             raise ConfigEntryAuthFailed(f"Credentials expired: {err}") from err
         except ConfigEntryAuthFailed:
-            self.consecutive_update_failures += 1
+            self.consecutive_update_failures = MAX_CONSECUTIVE_UPDATE_FAILURES
             raise
         except ApiError as err:
             self.consecutive_update_failures += 1
@@ -305,6 +308,11 @@ class UhomeDataUpdateCoordinator(DataUpdateCoordinator):
                     _LOGGER.debug(
                         "Received update for unknown device: %s", device_id
                     )
+
+            # A successful authenticated push proves the channel is alive —
+            # reset the poll-failure counter so entities stay available during
+            # transient poll outages while push continues to deliver state.
+            self.consecutive_update_failures = 0
 
             # Trigger data update for all entities
             self.async_set_updated_data(self.data)

--- a/custom_components/u_tec/coordinator.py
+++ b/custom_components/u_tec/coordinator.py
@@ -6,6 +6,7 @@ import logging
 from custom_components.u_tec.const import (
     DEFAULT_DISCOVERY_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
+    MAX_CONSECUTIVE_UPDATE_FAILURES,
     SIGNAL_DEVICE_UPDATE,
     SIGNAL_NEW_DEVICE,
 )
@@ -80,11 +81,24 @@ class UhomeDataUpdateCoordinator(DataUpdateCoordinator):
         self.blacklisted_devices = []
         self._discovery_interval = timedelta(seconds=discovery_interval)
         self._cancel_discovery: callable | None = None
+        # Consecutive failed polls. Entities stay available through a single
+        # transient failure; two in a row (or a device offline flag) marks them
+        # unavailable. Auth failures still raise ConfigEntryAuthFailed.
+        self.consecutive_update_failures = 0
         _LOGGER.info(
             "Uhome data coordinator initialized (poll=%ds, discovery=%ds)",
             scan_interval,
             discovery_interval,
         )
+
+    @property
+    def poll_healthy_enough(self) -> bool:
+        """Return True if poll failures have not crossed the unavailable threshold.
+
+        Used by entities instead of ``last_update_success`` so a single failed
+        poll does not blank every entity. Sustained failures still do.
+        """
+        return self.consecutive_update_failures < MAX_CONSECUTIVE_UPDATE_FAILURES
 
     async def async_start_periodic_discovery(self) -> None:
         """Start periodic device discovery separate from state polling."""
@@ -174,32 +188,42 @@ class UhomeDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> dict[str, dict]:
         """Fetch state for all known devices in a single bulk API call."""
         if not self.devices:
+            self.consecutive_update_failures = 0
             return {}
 
         _LOGGER.debug("Polling state for %d Uhome devices (bulk)", len(self.devices))
         try:
             device_ids = list(self.devices.keys())
             response = await self.api.get_device_state(device_ids, None)
-        except AuthenticationError as err:
-            raise ConfigEntryAuthFailed(f"Credentials expired: {err}") from err
+
+            # U-Tec returns HTTP 200 with an error envelope (e.g. INVALID_TOKEN) that
+            # get_device_state does not raise on — surface it instead of treating an
+            # error response as an empty-but-successful poll.
+            _raise_for_error_payload(response)
+
+            if response and "payload" in response:
+                for device_data in response["payload"].get("devices", []):
+                    device_id = device_data.get("id")
+                    if device_id and device_id in self.devices:
+                        await self.devices[device_id].update_state_data(device_data)
+
+            self.consecutive_update_failures = 0
+            return {
+                device_id: device.get_state_data()
+                for device_id, device in self.devices.items()
+            }
+        except (AuthenticationError, ConfigEntryAuthFailed):
+            self.consecutive_update_failures += 1
+            raise
         except ApiError as err:
+            self.consecutive_update_failures += 1
             raise UpdateFailed(f"Error communicating with API: {err}") from err
-
-        # U-Tec returns HTTP 200 with an error envelope (e.g. INVALID_TOKEN) that
-        # get_device_state does not raise on — surface it instead of treating an
-        # error response as an empty-but-successful poll.
-        _raise_for_error_payload(response)
-
-        if response and "payload" in response:
-            for device_data in response["payload"].get("devices", []):
-                device_id = device_data.get("id")
-                if device_id and device_id in self.devices:
-                    await self.devices[device_id].update_state_data(device_data)
-
-        return {
-            device_id: device.get_state_data()
-            for device_id, device in self.devices.items()
-        }
+        except UpdateFailed:
+            self.consecutive_update_failures += 1
+            raise
+        except Exception:
+            self.consecutive_update_failures += 1
+            raise
 
     async def update_push_data(self, push_data):
         """Process push update from webhook."""

--- a/custom_components/u_tec/diagnostics.py
+++ b/custom_components/u_tec/diagnostics.py
@@ -104,6 +104,8 @@ async def async_get_config_entry_diagnostics(
         "config_entry": async_redact_data(entry.as_dict(), REDACT_KEYS),
         "coordinator_data": {
             "last_update_success": coordinator.last_update_success,
+            "consecutive_update_failures": coordinator.consecutive_update_failures,
+            "poll_healthy_enough": coordinator.poll_healthy_enough,
             "device_count": len(coordinator.devices),
         },
         "devices": async_redact_data(device_data, REDACT_KEYS),

--- a/custom_components/u_tec/light.py
+++ b/custom_components/u_tec/light.py
@@ -42,7 +42,7 @@ _LOGGER = logging.getLogger(__name__)
 # confirm/timeout path (see _handle_push_update).
 # https://github.com/LF2b2w/Uhome-HA/issues/58
 
-# U-Tec reports brightness as 1-100, not 0-100. 
+# U-Tec reports brightness as 1-100, not 0-100.
 BRIGHTNESS_SCALE = (1, 100)
 
 
@@ -140,8 +140,11 @@ class UhomeLightEntity(CoordinatorEntity, LightEntity):
 
     @property
     def available(self) -> bool:
-        """Return True if entity is available."""
-        return self.coordinator.last_update_success and self._device.available
+        """Return True if entity is available.
+
+        Unavailable only when the device is offline or two consecutive polls failed.
+        """
+        return self.coordinator.poll_healthy_enough and self._device.available
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/u_tec/lock.py
+++ b/custom_components/u_tec/lock.py
@@ -137,8 +137,13 @@ class UhomeLockEntity(CoordinatorEntity, LockEntity):
 
     @property
     def available(self) -> bool:
-        """Return True if entity is available."""
-        return self.coordinator.last_update_success and self._device.available
+        """Return True if entity is available.
+
+        Unavailable only when the device itself is offline, or the coordinator
+        has failed two consecutive API polls (a single transient failure is
+        tolerated).
+        """
+        return self.coordinator.poll_healthy_enough and self._device.available
 
     @property
     def is_locked(self) -> bool:

--- a/custom_components/u_tec/manifest.json
+++ b/custom_components/u_tec/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "u_tec",
   "name": "U-Tec",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "codeowners": [
     "@LF2b2w",
     "@rbridal"

--- a/custom_components/u_tec/manifest.json
+++ b/custom_components/u_tec/manifest.json
@@ -1,17 +1,18 @@
 {
   "domain": "u_tec",
   "name": "U-Tec",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "codeowners": [
-    "@LF2b2w"
+    "@LF2b2w",
+    "@rbridal"
   ],
   "config_flow": true,
   "dependencies": [
     "application_credentials",
     "diagnostics"
   ],
-  "documentation": "https://github.com/LF2b2w/Uhome-HA",
-  "issue_tracker": "https://github.com/LF2b2w/Uhome-HA/issues",
+  "documentation": "https://github.com/rbridal/Uhome-HA",
+  "issue_tracker": "https://github.com/rbridal/Uhome-HA/issues",
   "iot_class": "cloud_polling",
   "requirements": [
     "utec_py_LF2b2w==0.4.0"

--- a/custom_components/u_tec/manifest.json
+++ b/custom_components/u_tec/manifest.json
@@ -1,18 +1,17 @@
 {
   "domain": "u_tec",
   "name": "U-Tec",
-  "version": "0.4.2",
+  "version": "0.4.0",
   "codeowners": [
-    "@LF2b2w",
-    "@rbridal"
+    "@LF2b2w"
   ],
   "config_flow": true,
   "dependencies": [
     "application_credentials",
     "diagnostics"
   ],
-  "documentation": "https://github.com/rbridal/Uhome-HA",
-  "issue_tracker": "https://github.com/rbridal/Uhome-HA/issues",
+  "documentation": "https://github.com/LF2b2w/Uhome-HA",
+  "issue_tracker": "https://github.com/LF2b2w/Uhome-HA/issues",
   "iot_class": "cloud_polling",
   "requirements": [
     "utec_py_LF2b2w==0.4.0"

--- a/custom_components/u_tec/sensor.py
+++ b/custom_components/u_tec/sensor.py
@@ -87,10 +87,9 @@ class UhomeBatterySensorEntity(CoordinatorEntity, SensorEntity):
     def available(self) -> bool:
         """Return True if entity is available.
 
-        Unavailable only when the device is offline or two consecutive polls failed.
+        Unavailable only when the device is offline or consecutive polls failed.
         """
-        device_available = getattr(self._device, "available", True)
-        return self.coordinator.poll_healthy_enough and device_available
+        return self.coordinator.poll_healthy_enough and self._device.available
 
     @property
     def native_value(self) -> int | None:

--- a/custom_components/u_tec/sensor.py
+++ b/custom_components/u_tec/sensor.py
@@ -84,6 +84,15 @@ class UhomeBatterySensorEntity(CoordinatorEntity, SensorEntity):
         self._attr_native_unit_of_measurement = PERCENTAGE
 
     @property
+    def available(self) -> bool:
+        """Return True if entity is available.
+
+        Unavailable only when the device is offline or two consecutive polls failed.
+        """
+        device_available = getattr(self._device, "available", True)
+        return self.coordinator.poll_healthy_enough and device_available
+
+    @property
     def native_value(self) -> int | None:
         """Return battery level."""
         return self._device.battery_level

--- a/custom_components/u_tec/strings.json
+++ b/custom_components/u_tec/strings.json
@@ -26,13 +26,13 @@
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     },
     "create_entry": {
-    "default": "[%key:common::config_flow::create_entry::authenticated%]"
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
     },
-      "error": {
-        "no_api_conf": "API not available",
-        "CE_invalid": "Invalid configuration",
-        "cannot_connect": "Failed to connect to API",
-        "empty_credentials": "Both Client ID and Client Secret are required."
+    "error": {
+      "no_api_conf": "API not available",
+      "CE_invalid": "Invalid configuration",
+      "cannot_connect": "Failed to connect to API",
+      "empty_credentials": "Both Client ID and Client Secret are required."
     }
   },
   "options": {
@@ -51,44 +51,51 @@
           "push_devices": "Devices"
         }
       },
-        "device_selection": {
-          "title": "Select Active Devices",
-          "description": "Choose which devices should be active in HomeAssistant.",
-          "data": {
-            "selected_devices": "Devices"
-          }
-        },
-        "optimistic_updates": {
-          "title": "Optimistic Updates",
-          "description": "Pick how each device type should reflect commands. 'All' writes optimistic state for every device of that type, 'None' waits for confirmed state, 'Custom' lets you pick specific devices.",
-          "data": {
-            "lights_mode": "Lights",
-            "switches_mode": "Switches",
-            "locks_mode": "Locks"
-          }
-        },
-        "pick_lights": {
-          "title": "Optimistic Lights",
-          "description": "Select the light devices that should use optimistic updates. Unselected lights will wait for confirmed state.",
-          "data": {
-            "optimistic_lights": "Optimistic lights"
-          }
-        },
-        "pick_switches": {
-          "title": "Optimistic Switches",
-          "description": "Select the switch devices that should use optimistic updates. Unselected switches will wait for confirmed state.",
-          "data": {
-            "optimistic_switches": "Optimistic switches"
-          }
-        },
-        "pick_locks": {
-          "title": "Optimistic Locks",
-          "description": "Select the lock devices that should use optimistic updates. Unselected locks will wait for confirmed state.",
-          "data": {
-            "optimistic_locks": "Optimistic locks"
-          }
+      "device_selection": {
+        "title": "Select Active Devices",
+        "description": "Choose which devices should be active in HomeAssistant.",
+        "data": {
+          "selected_devices": "Devices"
+        }
+      },
+      "optimistic_updates": {
+        "title": "Optimistic Updates",
+        "description": "Pick how each device type should reflect commands. 'All' writes optimistic state for every device of that type, 'None' waits for confirmed state, 'Custom' lets you pick specific devices.",
+        "data": {
+          "lights_mode": "Lights",
+          "switches_mode": "Switches",
+          "locks_mode": "Locks"
+        }
+      },
+      "pick_lights": {
+        "title": "Optimistic Lights",
+        "description": "Select the light devices that should use optimistic updates. Unselected lights will wait for confirmed state.",
+        "data": {
+          "optimistic_lights": "Optimistic lights"
+        }
+      },
+      "pick_switches": {
+        "title": "Optimistic Switches",
+        "description": "Select the switch devices that should use optimistic updates. Unselected switches will wait for confirmed state.",
+        "data": {
+          "optimistic_switches": "Optimistic switches"
+        }
+      },
+      "pick_locks": {
+        "title": "Optimistic Locks",
+        "description": "Select the lock devices that should use optimistic updates. Unselected locks will wait for confirmed state.",
+        "data": {
+          "optimistic_locks": "Optimistic locks"
+        }
+      },
+      "polling_interval": {
+        "title": "Polling Interval",
+        "description": "How often Home Assistant should poll the U-Tec API for device state. With working push (cloudhook) updates you can raise this (e.g. 300–600 seconds). The default of 10 seconds suits installs that rely mainly on polling.",
+        "data": {
+          "scan_interval": "Poll interval"
         }
       }
+    }
   },
   "selector": {
     "optimistic_mode": {

--- a/custom_components/u_tec/switch.py
+++ b/custom_components/u_tec/switch.py
@@ -84,8 +84,11 @@ class UhomeSwitchEntity(CoordinatorEntity, SwitchEntity):
 
     @property
     def available(self) -> bool:
-        """Return True if entity is available."""
-        return self.coordinator.last_update_success and self._device.available
+        """Return True if entity is available.
+
+        Unavailable only when the device is offline or two consecutive polls failed.
+        """
+        return self.coordinator.poll_healthy_enough and self._device.available
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/u_tec/translations/en.json
+++ b/custom_components/u_tec/translations/en.json
@@ -1,61 +1,68 @@
 {
-    "config": {
-        "step": {
-            "user": {
-                "menu_options": {
-                "title": "Connect to Your Service",
-                "description": "Please set up Your Integration"
-                }
-            }
-        },
-        "abort": {
-            "already_configured": "Account is already configured"
-        },
-        "error": {
-            "auth": "Authentication failed"
-        }
-    },
-    "options": {
-        "step": {
-            "optimistic_updates": {
-                "title": "Optimistic Updates",
-                "description": "Pick how each device type should reflect commands. 'All' writes optimistic state for every device of that type, 'None' waits for confirmed state, 'Custom' lets you pick specific devices.",
-                "data": {
-                    "lights_mode": "Lights",
-                    "switches_mode": "Switches",
-                    "locks_mode": "Locks"
-                }
-            },
-            "pick_lights": {
-                "title": "Optimistic Lights",
-                "description": "Select the light devices that should use optimistic updates. Unselected lights will wait for confirmed state.",
-                "data": {
-                    "optimistic_lights": "Optimistic lights"
-                }
-            },
-            "pick_switches": {
-                "title": "Optimistic Switches",
-                "description": "Select the switch devices that should use optimistic updates. Unselected switches will wait for confirmed state.",
-                "data": {
-                    "optimistic_switches": "Optimistic switches"
-                }
-            },
-            "pick_locks": {
-                "title": "Optimistic Locks",
-                "description": "Select the lock devices that should use optimistic updates. Unselected locks will wait for confirmed state.",
-                "data": {
-                    "optimistic_locks": "Optimistic locks"
-                }
-            }
-        }
-    },
-    "selector": {
-        "optimistic_mode": {
-            "options": {
-                "all": "All devices optimistic",
-                "none": "No devices optimistic",
-                "custom": "Custom per-device"
-            }
-        }
-    }
+   "config": {
+       "step": {
+           "user": {
+               "menu_options": {
+               "title": "Connect to Your Service",
+               "description": "Please set up Your Integration"
+               }
+           }
+       },
+       "abort": {
+           "already_configured": "Account is already configured"
+       },
+       "error": {
+           "auth": "Authentication failed"
+       }
+   },
+   "options": {
+       "step": {
+           "optimistic_updates": {
+               "title": "Optimistic Updates",
+               "description": "Pick how each device type should reflect commands. 'All' writes optimistic state for every device of that type, 'None' waits for confirmed state, 'Custom' lets you pick specific devices.",
+               "data": {
+                   "lights_mode": "Lights",
+                   "switches_mode": "Switches",
+                   "locks_mode": "Locks"
+               }
+           },
+           "pick_lights": {
+               "title": "Optimistic Lights",
+               "description": "Select the light devices that should use optimistic updates. Unselected lights will wait for confirmed state.",
+               "data": {
+                   "optimistic_lights": "Optimistic lights"
+               }
+           },
+           "pick_switches": {
+               "title": "Optimistic Switches",
+               "description": "Select the switch devices that should use optimistic updates. Unselected switches will wait for confirmed state.",
+               "data": {
+                   "optimistic_switches": "Optimistic switches"
+               }
+           },
+           "pick_locks": {
+               "title": "Optimistic Locks",
+               "description": "Select the lock devices that should use optimistic updates. Unselected locks will wait for confirmed state.",
+               "data": {
+                   "optimistic_locks": "Optimistic locks"
+               }
+           },
+           "polling_interval": {
+               "title": "Polling Interval",
+               "description": "How often Home Assistant should poll the U-Tec API for device state. With working push (cloudhook) updates you can raise this (e.g. 300–600 seconds). The default of 10 seconds suits installs that rely mainly on polling.",
+               "data": {
+                   "scan_interval": "Poll interval"
+               }
+           }
+       }
+   },
+   "selector": {
+       "optimistic_mode": {
+           "options": {
+               "all": "All devices optimistic",
+               "none": "No devices optimistic",
+               "custom": "Custom per-device"
+           }
+       }
+   }
 }

--- a/tests/test_availability.py
+++ b/tests/test_availability.py
@@ -1,0 +1,75 @@
+"""Tests for entity availability (device offline + consecutive poll failures)."""
+
+from unittest.mock import MagicMock
+
+from custom_components.u_tec.const import (
+    CONF_OPTIMISTIC_LOCKS,
+    DOMAIN,
+    MAX_CONSECUTIVE_UPDATE_FAILURES,
+)
+from custom_components.u_tec.lock import UhomeLockEntity
+from tests.common import make_config_entry, make_fake_lock
+
+
+def _coord_with_lock():
+    entry = make_config_entry(options={CONF_OPTIMISTIC_LOCKS: True})
+    lock = make_fake_lock("lock-1", is_locked=True)
+    lock.available = True
+    coord = MagicMock()
+    coord.devices = {"lock-1": lock}
+    coord.config_entry = entry
+    coord.last_update_success = True
+    coord.consecutive_update_failures = 0
+    coord.poll_healthy_enough = True
+    coord.data = {}
+    return coord, lock
+
+
+def test_available_when_healthy():
+    coord, lock = _coord_with_lock()
+    ent = UhomeLockEntity(coord, "lock-1")
+    assert ent.available is True
+
+
+def test_available_through_single_poll_failure():
+    """One failed poll must not blank the entity."""
+    coord, lock = _coord_with_lock()
+    coord.consecutive_update_failures = 1
+    coord.poll_healthy_enough = (
+        coord.consecutive_update_failures < MAX_CONSECUTIVE_UPDATE_FAILURES
+    )
+    coord.last_update_success = False
+    ent = UhomeLockEntity(coord, "lock-1")
+    assert ent.available is True
+
+
+def test_unavailable_after_two_consecutive_poll_failures():
+    coord, lock = _coord_with_lock()
+    coord.consecutive_update_failures = 2
+    coord.poll_healthy_enough = (
+        coord.consecutive_update_failures < MAX_CONSECUTIVE_UPDATE_FAILURES
+    )
+    coord.last_update_success = False
+    ent = UhomeLockEntity(coord, "lock-1")
+    assert ent.available is False
+
+
+def test_unavailable_when_device_offline():
+    coord, lock = _coord_with_lock()
+    lock.available = False
+    ent = UhomeLockEntity(coord, "lock-1")
+    assert ent.available is False
+
+
+def test_poll_healthy_enough_property():
+    """Coordinator helper mirrors the consecutive-failure threshold."""
+    from custom_components.u_tec.coordinator import UhomeDataUpdateCoordinator
+
+    # Exercise the real property without a full HA setup.
+    c = object.__new__(UhomeDataUpdateCoordinator)
+    c.consecutive_update_failures = 0
+    assert c.poll_healthy_enough is True
+    c.consecutive_update_failures = 1
+    assert c.poll_healthy_enough is True
+    c.consecutive_update_failures = 2
+    assert c.poll_healthy_enough is False

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -15,6 +15,7 @@ def door_sensor_setup(hass):
     coord = MagicMock()
     coord.devices = {"lock-1": lock}
     coord.last_update_success = True
+    coord.poll_healthy_enough = True
     return coord, lock
 
 
@@ -37,7 +38,7 @@ def test_available_requires_coordinator_and_device(door_sensor_setup):
     ent = UhomeDoorSensor(coord, "lock-1")
     assert ent.available is True
 
-    coord.last_update_success = False
+    coord.poll_healthy_enough = False
     assert ent.available is False
 
 

--- a/tests/test_coordinator_failures.py
+++ b/tests/test_coordinator_failures.py
@@ -1,0 +1,96 @@
+"""Tests for consecutive poll-failure tracking and push/auth interaction."""
+
+import pytest
+
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from utec_py.exceptions import ApiError, AuthenticationError
+
+from custom_components.u_tec.const import MAX_CONSECUTIVE_UPDATE_FAILURES
+from custom_components.u_tec.coordinator import UhomeDataUpdateCoordinator
+from tests.common import make_config_entry, make_fake_switch
+
+
+@pytest.fixture
+async def coordinator(hass, mock_uhome_api):
+    entry = make_config_entry()
+    entry.add_to_hass(hass)
+    return UhomeDataUpdateCoordinator(
+        hass, mock_uhome_api, config_entry=entry, scan_interval=10, discovery_interval=300,
+    )
+
+
+async def test_failure_counter_increments_and_resets_on_success(
+    coordinator, mock_uhome_api,
+):
+    sw = make_fake_switch("sw-1")
+    sw.get_state_data = lambda: {}
+    coordinator.devices["sw-1"] = sw
+
+    mock_uhome_api.get_device_state.side_effect = ApiError(500, "blip")
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+    assert coordinator.consecutive_update_failures == 1
+    assert coordinator.poll_healthy_enough is True
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+    assert coordinator.consecutive_update_failures == 2
+    assert coordinator.poll_healthy_enough is False
+
+    mock_uhome_api.get_device_state.side_effect = None
+    mock_uhome_api.get_device_state.return_value = {
+        "payload": {"devices": [{"id": "sw-1", "states": []}]}
+    }
+    await coordinator._async_update_data()
+    assert coordinator.consecutive_update_failures == 0
+    assert coordinator.poll_healthy_enough is True
+
+
+async def test_auth_failure_sets_counter_to_threshold(
+    coordinator, mock_uhome_api,
+):
+    """Auth failures must immediately mark entities unavailable (scheduler stops)."""
+    coordinator.devices["sw-1"] = make_fake_switch("sw-1")
+    mock_uhome_api.get_device_state.side_effect = AuthenticationError("bad token")
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()
+
+    assert (
+        coordinator.consecutive_update_failures == MAX_CONSECUTIVE_UPDATE_FAILURES
+    )
+    assert coordinator.poll_healthy_enough is False
+
+
+async def test_invalid_token_envelope_sets_counter_to_threshold(
+    coordinator, mock_uhome_api,
+):
+    coordinator.devices["sw-1"] = make_fake_switch("sw-1")
+    mock_uhome_api.get_device_state.return_value = {
+        "payload": {"error": {"code": "INVALID_TOKEN", "message": "expired"}}
+    }
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()
+
+    assert (
+        coordinator.consecutive_update_failures == MAX_CONSECUTIVE_UPDATE_FAILURES
+    )
+    assert coordinator.poll_healthy_enough is False
+
+
+async def test_successful_push_resets_failure_counter(coordinator):
+    """Push proving the channel is alive must restore availability."""
+    sw = make_fake_switch("sw-1")
+    coordinator.devices["sw-1"] = sw
+    coordinator.consecutive_update_failures = MAX_CONSECUTIVE_UPDATE_FAILURES
+    assert coordinator.poll_healthy_enough is False
+
+    await coordinator.update_push_data(
+        [{"id": "sw-1", "states": []}]
+    )
+
+    assert coordinator.consecutive_update_failures == 0
+    assert coordinator.poll_healthy_enough is True
+    sw.update_state_data.assert_awaited_once()

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -34,6 +34,8 @@ def coord_with_lock(hass):
     coord.devices = {"lock-1": lock}
     coord.config_entry = entry
     coord.last_update_success = True
+    coord.consecutive_update_failures = 0
+    coord.poll_healthy_enough = True
     coord.data = {}
     return coord, lock
 
@@ -113,6 +115,7 @@ async def test_setup_entry_excludes_non_lock_devices(hass):
     coord.devices = {"lock-1": lock, "sw-1": switch}
     coord.config_entry = entry
     coord.last_update_success = True
+    coord.poll_healthy_enough = True
     coord.data = {}
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"coordinator": coord}
@@ -127,11 +130,12 @@ async def test_setup_entry_excludes_non_lock_devices(hass):
 
 
 # ---------------------------------------------------------------------------
-# available returns False when coordinator or device unavailable
+# available: device offline OR consecutive poll failures threshold
 # ---------------------------------------------------------------------------
 
-def test_available_false_when_coordinator_update_failed(coord_with_lock):
+def test_available_false_when_consecutive_polls_failed(coord_with_lock):
     coord, lock = coord_with_lock
+    coord.poll_healthy_enough = False
     coord.last_update_success = False
     ent = UhomeLockEntity(coord, "lock-1")
     assert ent.available is False

--- a/tests/test_scan_interval.py
+++ b/tests/test_scan_interval.py
@@ -1,0 +1,41 @@
+"""Tests for scan_interval resolution and clamping."""
+
+from custom_components.u_tec import _resolve_scan_interval
+from custom_components.u_tec.const import (
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    MAX_SCAN_INTERVAL,
+    MIN_SCAN_INTERVAL,
+    YAML_CONFIG_KEY,
+)
+from tests.common import make_config_entry
+
+
+def test_resolve_prefers_ui_option(hass):
+    entry = make_config_entry(options={CONF_SCAN_INTERVAL: 120})
+    hass.data.setdefault(DOMAIN, {})[YAML_CONFIG_KEY] = {CONF_SCAN_INTERVAL: 30}
+    assert _resolve_scan_interval(hass, entry) == 120
+
+
+def test_resolve_falls_back_to_yaml(hass):
+    entry = make_config_entry(options={})
+    hass.data.setdefault(DOMAIN, {})[YAML_CONFIG_KEY] = {CONF_SCAN_INTERVAL: 45}
+    assert _resolve_scan_interval(hass, entry) == 45
+
+
+def test_resolve_falls_back_to_default(hass):
+    entry = make_config_entry(options={})
+    hass.data.setdefault(DOMAIN, {})
+    assert _resolve_scan_interval(hass, entry) == DEFAULT_SCAN_INTERVAL
+
+
+def test_resolve_clamps_yaml_below_minimum(hass):
+    entry = make_config_entry(options={})
+    hass.data.setdefault(DOMAIN, {})[YAML_CONFIG_KEY] = {CONF_SCAN_INTERVAL: 5}
+    assert _resolve_scan_interval(hass, entry) == MIN_SCAN_INTERVAL
+
+
+def test_resolve_clamps_above_maximum(hass):
+    entry = make_config_entry(options={CONF_SCAN_INTERVAL: 99999})
+    assert _resolve_scan_interval(hass, entry) == MAX_SCAN_INTERVAL

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -26,6 +26,7 @@ def coord_with_switch(hass):
     coord.devices = {"sw-1": sw}
     coord.config_entry = entry
     coord.last_update_success = True
+    coord.poll_healthy_enough = True
     coord.data = {}
     return coord, sw
 
@@ -97,6 +98,7 @@ async def test_assumed_state_respects_optimistic_config(hass):
     coord.devices = {"sw-1": sw}
     coord.config_entry = entry
     coord.last_update_success = True
+    coord.poll_healthy_enough = True
 
     ent = UhomeSwitchEntity(coord, "sw-1")
     ent._optimistic_is_on = True
@@ -120,6 +122,7 @@ async def test_setup_entry_filters_non_switch_devices(hass):
     coord.devices = {"sw-1": sw, "lock-1": lock}
     coord.config_entry = entry
     coord.last_update_success = True
+    coord.poll_healthy_enough = True
     coord.data = {}
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"coordinator": coord}
@@ -135,11 +138,11 @@ async def test_setup_entry_filters_non_switch_devices(hass):
     assert added[0]._device.device_id == "sw-1"
 
 
-# --- available returns False when last_update_success=False ---
+# --- available returns False when consecutive poll failures exceed threshold ---
 
 
 def test_available_false_when_coordinator_failed(hass):
-    """coordinator.last_update_success=False → available is False."""
+    """coordinator.poll_healthy_enough=False → available is False."""
     entry = make_config_entry()
     entry.add_to_hass(hass)
     sw = make_fake_switch("sw-1", available=True)
@@ -147,6 +150,7 @@ def test_available_false_when_coordinator_failed(hass):
     coord.devices = {"sw-1": sw}
     coord.config_entry = entry
     coord.last_update_success = False
+    coord.poll_healthy_enough = False
 
     ent = UhomeSwitchEntity(coord, "sw-1")
     assert ent.available is False
@@ -199,6 +203,7 @@ async def test_turn_on_no_optimistic_when_disabled(hass):
     coord.devices = {"sw-1": sw}
     coord.config_entry = entry
     coord.last_update_success = True
+    coord.poll_healthy_enough = True
 
     ent = UhomeSwitchEntity(coord, "sw-1")
     ent.hass = hass
@@ -224,6 +229,7 @@ async def test_turn_off_no_optimistic_when_disabled(hass):
     coord.devices = {"sw-1": sw}
     coord.config_entry = entry
     coord.last_update_success = True
+    coord.poll_healthy_enough = True
 
     ent = UhomeSwitchEntity(coord, "sw-1")
     ent.hass = hass

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -13,7 +13,7 @@ def _make_request(
     *,
     body: bytes = b"{}",
     headers: dict | None = None,
-    json_data: dict | None = None,
+    json_data: dict | list | None = None,
     support_read: bool = True,
     support_json: bool = True,
 ):
@@ -113,6 +113,20 @@ async def test_accepts_cloudhook_style_request_without_read(webhook_handler, has
     resp = await h._handle_webhook(hass, "wh-id", req)
     assert resp.status == 200
     coord.update_push_data.assert_awaited_once()
+
+
+async def test_accepts_cloudhook_list_payload_without_read(webhook_handler, hass):
+    """Cloudhook MockRequest with a top-level list body (issue #30 shape)."""
+    h, coord = webhook_handler
+    list_payload = [{"id": "lock-1", "states": []}]
+    req = _make_request(
+        support_read=False,
+        json_data=list_payload,
+        headers={"Authorization": "Bearer correct-secret"},
+    )
+    resp = await h._handle_webhook(hass, "wh-id", req)
+    assert resp.status == 200
+    coord.update_push_data.assert_awaited_once_with(list_payload)
 
 
 async def test_rejects_unknown_entry_id(hass, mock_uhome_api):

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -8,11 +8,45 @@ from custom_components.u_tec.api import AsyncPushUpdateHandler
 from custom_components.u_tec.const import DOMAIN
 
 
-def _make_request(method: str = "POST", *, body: bytes = b"{}", headers: dict | None = None):
+def _make_request(
+    method: str = "POST",
+    *,
+    body: bytes = b"{}",
+    headers: dict | None = None,
+    json_data: dict | None = None,
+    support_read: bool = True,
+    support_json: bool = True,
+):
+    """Build a request mock supporting read() and/or json().
+
+    Cloudhooks use a MockRequest with json() but no read(). Local deliveries
+    use a full aiohttp Request with both.
+    """
     req = MagicMock()
     req.method = method
-    req.read = AsyncMock(return_value=body)
     req.headers = headers or {}
+
+    if support_read:
+        req.read = AsyncMock(return_value=body)
+    else:
+        # Simulate cloud MockRequest — no read attribute at all.
+        del req.read
+
+    if support_json:
+        if json_data is not None:
+            req.json = AsyncMock(return_value=json_data)
+        else:
+            import json as _json
+
+            try:
+                parsed = _json.loads(body)
+            except Exception:  # noqa: BLE001
+                req.json = AsyncMock(side_effect=ValueError("bad json"))
+            else:
+                req.json = AsyncMock(return_value=parsed)
+    else:
+        del req.json
+
     return req
 
 
@@ -35,7 +69,7 @@ async def test_rejects_non_post_method(webhook_handler, hass):
 
 async def test_rejects_invalid_json_body(webhook_handler, hass):
     h, _ = webhook_handler
-    req = _make_request(body=b"not-json")
+    req = _make_request(body=b"not-json", support_json=False)
     resp = await h._handle_webhook(hass, "wh-id", req)
     assert resp.status == 400
 
@@ -61,6 +95,19 @@ async def test_accepts_correct_bearer_token(webhook_handler, hass):
     h, coord = webhook_handler
     req = _make_request(
         body=b'{"payload": {"devices": []}}',
+        headers={"Authorization": "Bearer correct-secret"},
+    )
+    resp = await h._handle_webhook(hass, "wh-id", req)
+    assert resp.status == 200
+    coord.update_push_data.assert_awaited_once()
+
+
+async def test_accepts_cloudhook_style_request_without_read(webhook_handler, hass):
+    """Nabu Casa cloudhooks deliver MockRequest with json() but no read()."""
+    h, coord = webhook_handler
+    req = _make_request(
+        support_read=False,
+        json_data={"payload": {"devices": []}},
         headers={"Authorization": "Bearer correct-secret"},
     )
     resp = await h._handle_webhook(hass, "wh-id", req)

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,6 +1,6 @@
 """Tests for AsyncPushUpdateHandler._handle_webhook (security boundary)."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -129,6 +129,51 @@ async def test_accepts_cloudhook_list_payload_without_read(webhook_handler, hass
     coord.update_push_data.assert_awaited_once_with(list_payload)
 
 
+async def test_accepts_list_payload_via_read_fallback(webhook_handler, hass):
+    """read()-only path with a top-level list body (no json())."""
+    h, coord = webhook_handler
+    list_body = b'[{"id": "lock-1", "states": []}]'
+    req = _make_request(
+        body=list_body,
+        support_json=False,
+        headers={"Authorization": "Bearer correct-secret"},
+    )
+    resp = await h._handle_webhook(hass, "wh-id", req)
+    assert resp.status == 200
+    coord.update_push_data.assert_awaited_once()
+    args = coord.update_push_data.await_args.args[0]
+    assert isinstance(args, list)
+    assert args[0]["id"] == "lock-1"
+
+
+async def test_rejects_scalar_json_body(webhook_handler, hass):
+    """Top-level scalar JSON must 400 — not be forwarded to the coordinator."""
+    h, coord = webhook_handler
+    req = _make_request(
+        support_read=False,
+        json_data="not-an-object",
+        headers={"Authorization": "Bearer correct-secret"},
+    )
+    resp = await h._handle_webhook(hass, "wh-id", req)
+    assert resp.status == 400
+    coord.update_push_data.assert_not_awaited()
+
+
+async def test_rejects_null_json_body(webhook_handler, hass):
+    """Top-level null JSON must 400."""
+    h, coord = webhook_handler
+    # support_read=False already removes read(); force json() to return null.
+    req = _make_request(
+        support_read=False,
+        json_data={"placeholder": True},
+        headers={"Authorization": "Bearer correct-secret"},
+    )
+    req.json = AsyncMock(return_value=None)
+    resp = await h._handle_webhook(hass, "wh-id", req)
+    assert resp.status == 400
+    coord.update_push_data.assert_not_awaited()
+
+
 async def test_rejects_unknown_entry_id(hass, mock_uhome_api):
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="bogus")
     h._push_secret = "s"
@@ -166,3 +211,37 @@ async def test_rejects_when_push_secret_not_initialised(hass, mock_uhome_api):
     resp = await h._handle_webhook(hass, "wh-id", req)
     assert resp.status == 401
     coord.update_push_data.assert_not_awaited()
+
+
+async def test_unregister_always_attempts_cloudhook_delete(hass, mock_uhome_api):
+    """Unregister always calls _delete_cloudhook (idempotent; not gated on flag)."""
+    h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="entry-1")
+    h._unregister_webhook = True
+    h._used_cloudhook = False  # even when flag is False, still attempt delete
+
+    with patch("custom_components.u_tec.api.webhook.async_unregister") as mock_unreg, patch.object(
+        h, "_delete_cloudhook", new_callable=AsyncMock
+    ) as mock_delete:
+        await h.unregister_webhook()
+
+    mock_unreg.assert_called_once_with(hass, h.webhook_id)
+    mock_delete.assert_awaited_once()
+    assert h._used_cloudhook is False
+    assert h._unregister_webhook is None
+
+
+async def test_unregister_deletes_cloudhook_when_used(hass, mock_uhome_api):
+    """Full entry removal must delete the Nabu Casa cloudhook, not only local handler."""
+    h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="entry-1")
+    h._unregister_webhook = True
+    h._used_cloudhook = True
+
+    with patch("custom_components.u_tec.api.webhook.async_unregister") as mock_unreg, patch.object(
+        h, "_delete_cloudhook", new_callable=AsyncMock
+    ) as mock_delete:
+        await h.unregister_webhook()
+
+    mock_unreg.assert_called_once_with(hass, h.webhook_id)
+    mock_delete.assert_awaited_once()
+    assert h._used_cloudhook is False
+    assert h._unregister_webhook is None

--- a/tests/test_webhook_registration.py
+++ b/tests/test_webhook_registration.py
@@ -9,13 +9,14 @@ from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
 from custom_components.u_tec.api import AsyncPushUpdateHandler
 
+# Cloud is lazy-imported inside _resolve_webhook_url, so patch the real module.
+_CLOUD_ACTIVE = "homeassistant.components.cloud.async_active_subscription"
+_CLOUD_HOOK = "homeassistant.components.cloud.async_get_or_create_cloudhook"
+
 
 def _patch_no_cloud():
     """Disable the cloudhook path so tests exercise network.get_url fallbacks."""
-    return patch(
-        "custom_components.u_tec.api.cloud.async_active_subscription",
-        return_value=False,
-    )
+    return patch(_CLOUD_ACTIVE, return_value=False)
 
 
 async def test_register_succeeds_with_external_url(hass, mock_uhome_api):
@@ -46,11 +47,8 @@ async def test_register_prefers_cloudhook_when_cloud_active(hass, mock_uhome_api
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
     cloudhook_url = "https://hooks.nabu.casa/abc123"
 
-    with patch(
-        "custom_components.u_tec.api.cloud.async_active_subscription",
-        return_value=True,
-    ), patch(
-        "custom_components.u_tec.api.cloud.async_get_or_create_cloudhook",
+    with patch(_CLOUD_ACTIVE, return_value=True), patch(
+        _CLOUD_HOOK,
         new_callable=AsyncMock,
         return_value=cloudhook_url,
     ) as mock_cloudhook, patch(
@@ -77,11 +75,8 @@ async def test_register_falls_back_when_cloudhook_fails(hass, mock_uhome_api):
     """Cloudhook creation error → fall back to network.get_url."""
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
 
-    with patch(
-        "custom_components.u_tec.api.cloud.async_active_subscription",
-        return_value=True,
-    ), patch(
-        "custom_components.u_tec.api.cloud.async_get_or_create_cloudhook",
+    with patch(_CLOUD_ACTIVE, return_value=True), patch(
+        _CLOUD_HOOK,
         new_callable=AsyncMock,
         side_effect=RuntimeError("cloud unavailable"),
     ), patch(

--- a/tests/test_webhook_registration.py
+++ b/tests/test_webhook_registration.py
@@ -9,14 +9,15 @@ from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
 from custom_components.u_tec.api import AsyncPushUpdateHandler
 
-# Cloud is lazy-imported inside _resolve_webhook_url, so patch the real module.
-_CLOUD_ACTIVE = "homeassistant.components.cloud.async_active_subscription"
-_CLOUD_HOOK = "homeassistant.components.cloud.async_get_or_create_cloudhook"
+# Patch the helper so tests never import homeassistant.components.cloud.
+_TRY_CLOUDHOOK = (
+    "custom_components.u_tec.api.AsyncPushUpdateHandler._try_get_cloudhook_url"
+)
 
 
 def _patch_no_cloud():
     """Disable the cloudhook path so tests exercise network.get_url fallbacks."""
-    return patch(_CLOUD_ACTIVE, return_value=False)
+    return patch(_TRY_CLOUDHOOK, new_callable=AsyncMock, return_value=None)
 
 
 async def test_register_succeeds_with_external_url(hass, mock_uhome_api):
@@ -43,14 +44,12 @@ async def test_register_succeeds_with_external_url(hass, mock_uhome_api):
 
 
 async def test_register_prefers_cloudhook_when_cloud_active(hass, mock_uhome_api):
-    """Nabu Casa active → use cloudhook, skip network.get_url."""
+    """Cloudhook available → use it, skip network.get_url."""
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
     cloudhook_url = "https://hooks.nabu.casa/abc123"
 
-    with patch(_CLOUD_ACTIVE, return_value=True), patch(
-        _CLOUD_HOOK,
-        new_callable=AsyncMock,
-        return_value=cloudhook_url,
+    with patch(
+        _TRY_CLOUDHOOK, new_callable=AsyncMock, return_value=cloudhook_url
     ) as mock_cloudhook, patch(
         "custom_components.u_tec.api.network.get_url",
     ) as mock_get_url, patch(
@@ -63,7 +62,7 @@ async def test_register_prefers_cloudhook_when_cloud_active(hass, mock_uhome_api
         result = await h.async_register_webhook(auth_data=MagicMock())
 
     assert result is True
-    mock_cloudhook.assert_awaited_once_with(hass, h.webhook_id)
+    mock_cloudhook.assert_awaited_once()
     mock_get_url.assert_not_called()
     mock_uhome_api.set_push_status.assert_awaited_once()
     assert mock_uhome_api.set_push_status.await_args.args[0] == cloudhook_url
@@ -71,15 +70,11 @@ async def test_register_prefers_cloudhook_when_cloud_active(hass, mock_uhome_api
     assert h.webhook_url == cloudhook_url
 
 
-async def test_register_falls_back_when_cloudhook_fails(hass, mock_uhome_api):
-    """Cloudhook creation error → fall back to network.get_url."""
+async def test_register_falls_back_when_cloudhook_unavailable(hass, mock_uhome_api):
+    """No cloudhook → fall back to network.get_url."""
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
 
-    with patch(_CLOUD_ACTIVE, return_value=True), patch(
-        _CLOUD_HOOK,
-        new_callable=AsyncMock,
-        side_effect=RuntimeError("cloud unavailable"),
-    ), patch(
+    with _patch_no_cloud(), patch(
         "custom_components.u_tec.api.network.get_url",
         return_value="https://ha.example.com",
     ), patch(
@@ -113,7 +108,7 @@ async def test_register_fails_when_no_url_available(hass, mock_uhome_api):
 
 
 async def test_register_falls_back_through_url_strategies(hass, mock_uhome_api):
-    """First strategy fails, second succeeds — cloud fallback path."""
+    """First strategy fails, second succeeds — network fallback path."""
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
 
     call_count = [0]

--- a/tests/test_webhook_registration.py
+++ b/tests/test_webhook_registration.py
@@ -1,7 +1,7 @@
 """Tests for AsyncPushUpdateHandler.async_register_webhook — URL resolution."""
 
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.helpers.network import NoURLAvailableError
 from homeassistant.util import dt as dt_util
@@ -10,10 +10,18 @@ from pytest_homeassistant_custom_component.common import async_fire_time_changed
 from custom_components.u_tec.api import AsyncPushUpdateHandler
 
 
+def _patch_no_cloud():
+    """Disable the cloudhook path so tests exercise network.get_url fallbacks."""
+    return patch(
+        "custom_components.u_tec.api.cloud.async_active_subscription",
+        return_value=False,
+    )
+
+
 async def test_register_succeeds_with_external_url(hass, mock_uhome_api):
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
 
-    with patch(
+    with _patch_no_cloud(), patch(
         "custom_components.u_tec.api.network.get_url",
         return_value="https://ha.example.com",
     ), patch(
@@ -30,12 +38,76 @@ async def test_register_succeeds_with_external_url(hass, mock_uhome_api):
 
     assert result is True
     mock_uhome_api.set_push_status.assert_awaited_once()
+    assert h._used_cloudhook is False
+
+
+async def test_register_prefers_cloudhook_when_cloud_active(hass, mock_uhome_api):
+    """Nabu Casa active → use cloudhook, skip network.get_url."""
+    h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
+    cloudhook_url = "https://hooks.nabu.casa/abc123"
+
+    with patch(
+        "custom_components.u_tec.api.cloud.async_active_subscription",
+        return_value=True,
+    ), patch(
+        "custom_components.u_tec.api.cloud.async_get_or_create_cloudhook",
+        new_callable=AsyncMock,
+        return_value=cloudhook_url,
+    ) as mock_cloudhook, patch(
+        "custom_components.u_tec.api.network.get_url",
+    ) as mock_get_url, patch(
+        "custom_components.u_tec.api.webhook.async_register",
+        return_value=None,
+    ), patch(
+        "custom_components.u_tec.api.async_track_time_interval",
+        return_value=MagicMock(),
+    ):
+        result = await h.async_register_webhook(auth_data=MagicMock())
+
+    assert result is True
+    mock_cloudhook.assert_awaited_once_with(hass, h.webhook_id)
+    mock_get_url.assert_not_called()
+    mock_uhome_api.set_push_status.assert_awaited_once()
+    assert mock_uhome_api.set_push_status.await_args.args[0] == cloudhook_url
+    assert h._used_cloudhook is True
+    assert h.webhook_url == cloudhook_url
+
+
+async def test_register_falls_back_when_cloudhook_fails(hass, mock_uhome_api):
+    """Cloudhook creation error → fall back to network.get_url."""
+    h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
+
+    with patch(
+        "custom_components.u_tec.api.cloud.async_active_subscription",
+        return_value=True,
+    ), patch(
+        "custom_components.u_tec.api.cloud.async_get_or_create_cloudhook",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("cloud unavailable"),
+    ), patch(
+        "custom_components.u_tec.api.network.get_url",
+        return_value="https://ha.example.com",
+    ), patch(
+        "custom_components.u_tec.api.webhook.async_generate_url",
+        return_value="https://ha.example.com/api/webhook/x",
+    ), patch(
+        "custom_components.u_tec.api.webhook.async_register",
+        return_value=None,
+    ), patch(
+        "custom_components.u_tec.api.async_track_time_interval",
+        return_value=MagicMock(),
+    ):
+        result = await h.async_register_webhook(auth_data=MagicMock())
+
+    assert result is True
+    assert h._used_cloudhook is False
+    mock_uhome_api.set_push_status.assert_awaited_once()
 
 
 async def test_register_fails_when_no_url_available(hass, mock_uhome_api):
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
 
-    with patch(
+    with _patch_no_cloud(), patch(
         "custom_components.u_tec.api.network.get_url",
         side_effect=NoURLAvailableError("no external URL configured"),
     ):
@@ -57,7 +129,7 @@ async def test_register_falls_back_through_url_strategies(hass, mock_uhome_api):
             raise NoURLAvailableError("first strategy unavailable")
         return "https://cloud.example.com"
 
-    with patch(
+    with _patch_no_cloud(), patch(
         "custom_components.u_tec.api.network.get_url", side_effect=_get_url,
     ), patch(
         "custom_components.u_tec.api.webhook.async_generate_url",
@@ -81,7 +153,7 @@ async def test_register_fails_when_api_set_push_status_errors(hass, mock_uhome_a
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
     mock_uhome_api.set_push_status.side_effect = ApiError(500, "fail")
 
-    with patch(
+    with _patch_no_cloud(), patch(
         "custom_components.u_tec.api.network.get_url",
         return_value="https://ha.example.com",
     ), patch(
@@ -102,7 +174,7 @@ async def test_register_fails_when_api_set_push_status_errors(hass, mock_uhome_a
 async def test_register_generates_new_secret_each_call(hass, mock_uhome_api):
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
 
-    with patch(
+    with _patch_no_cloud(), patch(
         "custom_components.u_tec.api.network.get_url",
         return_value="https://ha.example.com",
     ), patch(
@@ -155,7 +227,7 @@ async def test_register_twice_does_not_re_register_handler(hass, mock_uhome_api)
     """
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
 
-    with patch(
+    with _patch_no_cloud(), patch(
         "custom_components.u_tec.api.network.get_url",
         return_value="https://ha.example.com",
     ), patch(
@@ -184,7 +256,7 @@ async def test_24h_reregister_timer_does_not_raise(hass, mock_uhome_api):
     """
     h = AsyncPushUpdateHandler(hass, mock_uhome_api, entry_id="e1")
 
-    with patch(
+    with _patch_no_cloud(), patch(
         "custom_components.u_tec.api.network.get_url",
         return_value="https://ha.example.com",
     ), patch(


### PR DESCRIPTION
## Summary
Two reliability/UX improvements independent of cloudhook support:

1. **Availability** — entities go unavailable only when the device is offline
   or the coordinator has two consecutive failed polls (not after a single blip).
2. **Poll interval** — configurable in the integration options UI (10–3600s),
   applied without a full reload. Useful when push/cloudhooks carry most updates.

## Testing
- 247 passed, 1 skipped