### PR TITLE
chore: bump manifest version to 0.5.0

### DIFF
--- a/custom_components/u_tec/manifest.json
+++ b/custom_components/u_tec/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "u_tec",
   "name": "U-Tec",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "codeowners": [
     "@LF2b2w"
   ],


### PR DESCRIPTION
Bumps `manifest.json` to 0.5.0, which the v0.5.0 tag shipped as 0.4.0.

Only the `version` field. `requirements` is left at `utec_py_LF2b2w==0.4.0`, since that's the library version and the tag doesn't change it.

This makes the *next* tag correct rather than retroactively fixing v0.5.0 — the underlying thing is that the bump lands after the tag rather than before it, which is #62.
